### PR TITLE
Improve codd's performance and develop benchmarks

### DIFF
--- a/.env
+++ b/.env
@@ -12,5 +12,3 @@ PGUSER=codd_admin
 PGSUPERUSER=postgres
 PGDATA=./local/shell-postgres-datadir/
 LANG=C.UTF-8
-
-EXPECTED_BENCHMARK_FILE=bench/expected-perf/local.json

--- a/.env
+++ b/.env
@@ -12,3 +12,5 @@ PGUSER=codd_admin
 PGSUPERUSER=postgres
 PGDATA=./local/shell-postgres-datadir/
 LANG=C.UTF-8
+
+EXPECTED_BENCHMARK_FILE=bench/expected-perf/local.json

--- a/.envrc
+++ b/.envrc
@@ -3,7 +3,7 @@ strict_env
 mkdir -p local/direnv
 
 IFS=$'\n' local files_to_watch=($(find . -name '*.nix' -o -name '*.cabal' -o -name 'flake.lock'))
-watch_file "${files_to_watch[@]}" stack.yaml
+watch_file "${files_to_watch[@]}" stack.yaml stack-aeson-2.yaml
 
 # Source cached environment and treat some environment variables
 # especially.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,14 @@ jobs:
     - name: Build codd's tests
       run: nix build --no-link .#codd:test:codd-test
 
+    - name: Build benchmarks
+      run: nix build --no-link .#codd:bench:codd-bench
+
     - name: Run tests
       run: ./scripts/run-tests.sh --with-nix
+
+    - name: Run benchmarks
+      run: nix run .#codd:bench:codd-bench
 
     - name: Build codd's library's haddocks
       run: nix build --no-link .#packages.x86_64-linux.codd:lib:codd.doc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,8 @@ jobs:
 
     - name: Run benchmarks
       run: nix run .#codd:bench:codd-bench
+      env:
+        EXPECTED_BENCHMARK_FILE: bench/expected-perf/ci.json
 
     - name: Build codd's library's haddocks
       run: nix build --no-link .#packages.x86_64-linux.codd:lib:codd.doc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  CI: 1
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -68,8 +71,6 @@ jobs:
 
     - name: Run benchmarks
       run: nix run .#codd:bench:codd-bench
-      env:
-        EXPECTED_BENCHMARK_FILE: bench/expected-perf/ci.json
 
     - name: Build codd's library's haddocks
       run: nix build --no-link .#packages.x86_64-linux.codd:lib:codd.doc

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist-newstyle/
 
 # Nix build outputs
 results/
+
+# Result of cabal run -O2 --enable-profiling codd-bench
+codd-bench.prof

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -53,230 +53,207 @@ manySelect1s size = Streaming.replicate size "SELECT 1;"
 
 veryLargeCopy :: Monad m => Int -> Stream (Of Text) m ()
 veryLargeCopy size =
-    Streaming.yield "COPY sometable FROM STDIN WITH (FORMAT csv);\n"
-        >> Streaming.replicate size "4,Some name,2020-01-01\n"
-        >> Streaming.yield "\\.\n"
+  Streaming.yield "COPY sometable FROM STDIN WITH (FORMAT csv);\n"
+    >> Streaming.replicate size "4,Some name,2020-01-01\n"
+    >> Streaming.yield "\\.\n"
 
 parseMig :: Stream (Of Text) IO () -> IO (Stream (Of SqlPiece) IO ())
 parseMig contents = do
-    Right (SqlMigration { migrationSql } :: SqlMigration IO) <-
-        parseSqlMigration @IO "any-name.sql" (PureStream contents)
-    case migrationSql of
-        UnparsedSql   _ -> error "Error parsing SQL"
-        WellParsedSql s -> pure s
+  Right (SqlMigration { migrationSql } :: SqlMigration IO) <-
+    parseSqlMigration @IO "any-name.sql" (PureStream contents)
+  case migrationSql of
+    UnparsedSql   _ -> error "Error parsing SQL"
+    WellParsedSql s -> pure s
 
 superForce :: NFData a => IO a -> IO a
 superForce vio = vio >>= evaluate . force
 
 bench :: NFData a => String -> IO a -> IO Measured
 bench name f = do
-    msr@Measured {..} <- fst <$> measure
-        Benchmarkable
-            {
-                            -- TODO: Do we need to performGC in between runs or does the framework do it for us?
-              allocEnv      = \_ -> pure ()
-            , cleanEnv      = \_ _ -> pure ()
-            , runRepeatedly = \_ n -> forM_ [1 .. n] $ const $ superForce f
-            , perRun        = True -- If True, `runRepeatedly` is called with `n=1`. Not sure why this exists, though.
-            }
-        10
-    putStrLn
-        $  "--- Benchmark "
-        ++ name
-        ++ ": Wall time="
-        ++ secs measTime
-        ++ ", peak memory usage="
-        ++ show measPeakMbAllocated
-        ++ " MB."
-    pure msr
+  msr@Measured {..} <- fst <$> measure
+    Benchmarkable
+      {
+                          -- TODO: Do we need to performGC in between runs or does the framework do it for us?
+        allocEnv      = \_ -> pure ()
+      , cleanEnv      = \_ _ -> pure ()
+      , runRepeatedly = \_ n -> forM_ [1 .. n] $ const $ superForce f
+      , perRun        = True -- If True, `runRepeatedly` is called with `n=1`. Not sure why this exists, though.
+      }
+    10
+  putStrLn
+    $  "--- Benchmark "
+    ++ name
+    ++ ": Wall time="
+    ++ secs measTime
+    ++ ", peak memory usage="
+    ++ show measPeakMbAllocated
+    ++ " MB."
+  pure msr
 
 shouldBeF :: HasCallStack => String -> Double -> Double -> Double -> IO ()
 shouldBeF errorMsg tolerance actual expected =
-    unless (abs (actual - expected) <= tolerance)
-        $  expectationFailure
-        $  errorMsg
-        ++ ": Expected a number within "
-        ++ show tolerance
-        ++ " of "
-        ++ show expected
-        ++ " but got "
-        ++ show actual
+  unless (abs (actual - expected) <= tolerance)
+    $  expectationFailure
+    $  errorMsg
+    ++ ": Expected a number within "
+    ++ show tolerance
+    ++ " of "
+    ++ show expected
+    ++ " but got "
+    ++ show actual
 
 -- | With data that has all y values being the same, r2 is often calculated to be one of [-Infinity, Infinity, NaN].
 -- I haven't seen it happen in other conditions yet, and https://github.com/haskell/statistics/issues/111 seems
 -- to be slightly related, so I'm assuming that's the only case when it happens.
 r2ShouldBe1 :: HasCallStack => String -> Double -> IO ()
 r2ShouldBe1 errorMsg r2 =
-    unless (isNaN r2 || isInfinite r2) $ shouldBeF errorMsg 0.001 r2 1
+  unless (isNaN r2 || isInfinite r2) $ shouldBeF errorMsg 0.001 r2 1
 
 -- | Checks that the measured quantities approximately form a line that passes
 -- through (0,0).
 mustFormALineWithOrigin
-    :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
+  :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
 mustFormALineWithOrigin ms f = do
-    let xs = V.fromList $ map fst ms
-        ys = V.fromList $ map (f . snd) ms
-        (V.toList -> [_slope, yIntercept], r2) = olsRegress [xs] ys
-    -- print xs
-    -- print ys
-    -- print (_slope, yIntercept, r2)
-    shouldBeF "Line with origin (yIntercept)" 0.1 yIntercept 0
-    r2ShouldBe1 "Line with origin (r^2)" r2
+  let xs = V.fromList $ map fst ms
+      ys = V.fromList $ map (f . snd) ms
+      (V.toList -> [_slope, yIntercept], r2) = olsRegress [xs] ys
+  -- print xs
+  -- print ys
+  -- print (_slope, yIntercept, r2)
+  shouldBeF "Line with origin (yIntercept)" 0.1 yIntercept 0
+  r2ShouldBe1 "Line with origin (r^2)" r2
 
 -- | Checks that the measured quantities approximately form a horizontal line.
 mustFormAHorizontalLine
-    :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
+  :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
 mustFormAHorizontalLine ms f = do
-    let xs = V.fromList $ map fst ms
-        ys = V.fromList $ map (f . snd) ms
-        (V.toList -> [slope, _yIntercept], r2) = olsRegress [xs] ys
-    -- print xs
-    -- print ys
-    -- print (slope, _yIntercept, r2)
-    -- The error tolerance for the slope check is very stringent because so far
-    -- we only use it for the peak memory usage test, and those are Ints in Megabytes
-    -- so they really shouldn't vary unless we're very unlucky.
-    -- If more tests use this function, we should probably make the tolerance
-    -- an argument of it.
-    shouldBeF "Horizontal line (slope)" 0.000_01 slope 0
-    r2ShouldBe1 "Horizontal line (r^2)" r2
+  let xs = V.fromList $ map fst ms
+      ys = V.fromList $ map (f . snd) ms
+      (V.toList -> [slope, _yIntercept], r2) = olsRegress [xs] ys
+  -- print xs
+  -- print ys
+  -- print (slope, _yIntercept, r2)
+  -- The error tolerance for the slope check is very stringent because so far
+  -- we only use it for the peak memory usage test, and those are Ints in Megabytes
+  -- so they really shouldn't vary unless we're very unlucky.
+  -- If more tests use this function, we should probably make the tolerance
+  -- an argument of it.
+  shouldBeF "Horizontal line (slope)" 0.000_01 slope 0
+  r2ShouldBe1 "Horizontal line (r^2)" r2
 
 fromGcInt :: Int64 -> Double
 fromGcInt =
-    fromIntegral
-        . fromMaybe
-              (error
-                  "GC stats not enabled. Are you running benchmarks with +RTS -T ?"
-              )
-        . fromInt
+  fromIntegral
+    . fromMaybe
+        (error "GC stats not enabled. Are you running benchmarks with +RTS -T ?"
+        )
+    . fromInt
 
 avg :: [Double] -> Double
 avg [] = error "Average of empty list"
 avg xs = sum xs / fromIntegral (length xs) -- No need to fret with the implementation: our lists are small
 
 data CurrentPerf = CurrentPerf
-    { select1TimeAndMemory :: (Double, Double)
-    , copyTimeAndMemory    :: (Double, Double)
-    }
-    deriving stock Generic
-    deriving anyclass FromJSON
+  { select1TimeAndMemory :: (Double, Double)
+  , copyTimeAndMemory    :: (Double, Double)
+  }
+  deriving stock Generic
+  deriving anyclass FromJSON
 
 main :: IO ()
 main = do
-    IO.hSetBuffering IO.stdout IO.NoBuffering
-    IO.hSetBuffering IO.stderr IO.NoBuffering
+  IO.hSetBuffering IO.stdout IO.NoBuffering
+  IO.hSetBuffering IO.stderr IO.NoBuffering
 
-    -- initializeTime must run first: https://hackage.haskell.org/package/criterion-measurement-0.2.0.0/docs/Criterion-Measurement.html#v:initializeTime
-    initializeTime
+  -- initializeTime must run first: https://hackage.haskell.org/package/criterion-measurement-0.2.0.0/docs/Criterion-Measurement.html#v:initializeTime
+  initializeTime
 
-    -- This is very ad-hoc, but variance in GitHub actions is much greater than on my own machine,
-    -- and I don't want to increase variance tolerance on my machine as it's good for it to be tight.
-    -- So we check if we're in CI and increase our tolerance for divergent perf numbers.
-    isCI <- isJust <$> lookupEnv "CI"
-    let expectedPerfPath :: FilePath = if isCI
-            then "bench/expected-perf/ci.json"
-            else "bench/expected-perf/local.json"
-    putStrLn $ "Reading expected performance numbers from " ++ expectedPerfPath
-    CurrentPerf {..} <-
-        either (error "Could not decode expected performance file") id
-            <$> eitherDecodeFileStrict expectedPerfPath
+  -- This is very ad-hoc, but variance in GitHub actions is much greater than on my own machine,
+  -- and I don't want to increase variance tolerance on my machine as it's good for it to be tight.
+  -- So we check if we're in CI and increase our tolerance for divergent perf numbers.
+  isCI <- isJust <$> lookupEnv "CI"
+  let expectedPerfPath :: FilePath = if isCI
+        then "bench/expected-perf/ci.json"
+        else "bench/expected-perf/local.json"
+  putStrLn $ "Reading expected performance numbers from " ++ expectedPerfPath
+  CurrentPerf {..} <-
+    either (error "Could not decode expected performance file") id
+      <$> eitherDecodeFileStrict expectedPerfPath
 
-    let (diffWallTimeTolerance, diffMaxMemTolerance) =
-            if isCI then (0.9, 0.5) else (0.5, 0.5)
+  let (diffWallTimeTolerance, diffMaxMemTolerance) =
+        if isCI then (0.9, 1) else (0.5, 1)
 
-    hspec
-        $ describe
-              "Elapsed wall time must be linear with input size and max memory usage constant when streaming parse"
-        $ do
-        -- 1. Linear CPU time on input size means we're not accumulating anything
-        --    unreasonably when parsing in streaming fashion.
-        -- 2. Max memory usage constant is a must in a streaming parser as we should
-        --    be able to parse arbitrarily large SQL files.
-        --    Since peak MB allocated is an integer, however, it could be that it rounds to different numbers
-        --    on different runs despite the actual total max allocates bytes being very similar. This could
-        --    mess up our horizontal line check.
-              describe "Parsing several sequential 'SELECT 1;' statements" $ do
-                  rs :: [(Double, Measured)] <-
-                      runIO
-                      $ forM [10_000, 100_000, 500_000, 1_000_000]
-                      $ \n ->
-                            fmap (fromIntegral n, )
-                                $ bench ("SELECT 1 " ++ show n)
-                                $ do
-                              -- Uncomment the line below to make memory usage linear on input size
-                              -- and see memory usage rise and the test fail
-                              -- _ <- evaluate $ force [1 .. n]
-                                      parseMig (manySelect1s n)
-                                          >>= Streaming.any_
-                                                  (== CommentPiece
-                                                      "Not in the stream"
-                                                  )
+  hspec
+    $ describe
+        "Elapsed wall time must be linear with input size and max memory usage constant when streaming parse"
+    $ do
+      -- 1. Linear CPU time on input size means we're not accumulating anything
+      --    unreasonably when parsing in streaming fashion.
+      -- 2. Max memory usage constant is a must in a streaming parser as we should
+      --    be able to parse arbitrarily large SQL files.
+      --    Since peak MB allocated is an integer, however, it could be that it rounds to different numbers
+      --    on different runs despite the actual total max allocates bytes being very similar. This could
+      --    mess up our horizontal line check.
+        describe "Parsing several sequential 'SELECT 1;' statements" $ do
+          rs :: [(Double, Measured)] <-
+            runIO $ forM [10_000, 100_000, 500_000, 1_000_000] $ \n ->
+              fmap (fromIntegral n, ) $ bench ("SELECT 1 " ++ show n) $ do
+                      -- Uncomment the line below to make memory usage linear on input size
+                      -- and see memory usage rise and the test fail
+                      -- _ <- evaluate $ force [1 .. n]
+                parseMig (manySelect1s n)
+                  >>= Streaming.any_ (== CommentPiece "Not in the stream")
 
-                  it "Elapsed wall time must linear wrt input size"
-                      $ mustFormALineWithOrigin rs measTime
-                  it
-                          "Peak memory usage must be constant regardless of input size"
-                      $ mustFormAHorizontalLine
-                            rs
-                            (fromGcInt . measPeakMbAllocated)
-                  it "Must not be too different from expected performance" $ do
-                      let measures = map snd rs
-                      shouldBeF "Average wall time regression"
-                                diffWallTimeTolerance
-                                (avg (map measTime measures))
-                                (fst select1TimeAndMemory)
-                      shouldBeF
-                          "Max memory usage regression"
-                          diffMaxMemTolerance
-                          (maximum
-                              (map (fromGcInt . measPeakMbAllocated) measures)
-                          )
-                          (snd select1TimeAndMemory)
+          it "Elapsed wall time must linear wrt input size"
+            $ mustFormALineWithOrigin rs measTime
+          it "Peak memory usage must be constant regardless of input size"
+            $ mustFormAHorizontalLine rs (fromGcInt . measPeakMbAllocated)
+          it "Must not be too different from expected performance" $ do
+            let measures = map snd rs
+            shouldBeF "Average wall time regression"
+                      diffWallTimeTolerance
+                      (avg (map measTime measures))
+                      (fst select1TimeAndMemory)
+            shouldBeF
+              "Max memory usage regression"
+              diffMaxMemTolerance
+              (maximum (map (fromGcInt . measPeakMbAllocated) measures))
+              (snd select1TimeAndMemory)
 
-              describe "Parsing COPY statement" $ do
-                  rs :: [(Double, Measured)] <-
-                      runIO
-                      $ forM [10_000, 100_000, 500_000, 1_000_000]
-                      $ \n ->
-                            fmap (fromIntegral n, )
-                                $ bench ("COPY " ++ show n)
-                                $ do
-                          -- Uncomment the line below to make memory usage linear on input size
-                          -- and see memory usage rise and the test fail
-                          -- _ <- evaluate $ force [1 .. n]
-                                      parseMig (veryLargeCopy n)
-                                          >>= Streaming.any_
-                                                  (== CommentPiece
-                                                      "Not in the stream"
-                                                  )
+        describe "Parsing COPY statement" $ do
+          rs :: [(Double, Measured)] <-
+            runIO
+            $ forM [100_000, 500_000, 1_000_000] -- Only large-ish sizes or less memory will be used and we want constant memory usage
+            $ \n -> fmap (fromIntegral n, ) $ bench ("COPY " ++ show n) $ do
+                  -- Uncomment the line below to make memory usage linear on input size
+                  -- and see memory usage rise and the test fail
+                  -- _ <- evaluate $ force [1 .. n]
+                parseMig (veryLargeCopy n)
+                  >>= Streaming.any_ (== CommentPiece "Not in the stream")
 
-                  it "Elapsed wall time must linear wrt input size"
-                      $ mustFormALineWithOrigin rs measTime
-                  it
-                          "Peak memory usage must be constant regardless of input size"
-                      $ mustFormAHorizontalLine
-                            rs
-                            (fromGcInt . measPeakMbAllocated)
+          it "Elapsed wall time must linear wrt input size"
+            $ mustFormALineWithOrigin rs measTime
+          it "Peak memory usage must be constant regardless of input size"
+            $ mustFormAHorizontalLine rs (fromGcInt . measPeakMbAllocated)
 
-                  it "Must not be too different from expected performance" $ do
-                      let measures = map snd rs
-                      shouldBeF "Average wall time regression"
-                                diffWallTimeTolerance
-                                (avg (map measTime measures))
-                                (fst copyTimeAndMemory)
-                      shouldBeF
-                          "Max memory usage regression"
-                          diffMaxMemTolerance
-                          (maximum
-                              (map (fromGcInt . measPeakMbAllocated) measures)
-                          )
-                          (snd copyTimeAndMemory)
+          it "Must not be too different from expected performance" $ do
+            let measures = map snd rs
+            shouldBeF "Average wall time regression"
+                      diffWallTimeTolerance
+                      (avg (map measTime measures))
+                      (fst copyTimeAndMemory)
+            shouldBeF
+              "Max memory usage regression"
+              diffMaxMemTolerance
+              (maximum (map (fromGcInt . measPeakMbAllocated) measures))
+              (snd copyTimeAndMemory)
 
-                  it "Number of SQL pieces must be low to avoid too many round-trips" $ do
-                    -- The body of the contents inside COPY can be very large, so we don't want
-                    -- small pieces coming out of the parser to avoid too many unnecessary round-trips.
-                    -- Any changes to the parser will be detected by this test, but those should never
-                    -- increase the number of parsed pieces too much.
-                    len :: Int <- parseMig (veryLargeCopy 500_000) >>= Streaming.length_
-                    putStrLn "Hello"
-                    len `shouldBe` 10
+          it "Number of SQL pieces must be low to avoid too many round-trips"
+            $ do
+            -- The body of the contents inside COPY can be very large, so we don't want
+            -- small pieces coming out of the parser to avoid too many unnecessary round-trips.
+            -- Any changes to the parser will be detected by this test, but those should never
+            -- increase the number of parsed pieces too much.
+                len :: Int <-
+                  parseMig (veryLargeCopy 500_000) >>= Streaming.length_
+                len `shouldBe` 178

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,36 +1,212 @@
 {-# LANGUAGE NumericUnderscores #-}
 module Main where
 
-import Codd.Parsing (SqlPiece (..), PureStream (..), SqlMigration (..), ParsedSql (..), parseSqlMigration)
-import Criterion.Main (defaultMain, bgroup, bench, nfIO)
-import Data.Text (Text)
-import Streaming (Of)
-import Streaming.Prelude (Stream)
-import qualified Streaming.Prelude as Streaming
+import           Codd.Parsing                   ( ParsedSql(..)
+                                                , PureStream(..)
+                                                , SqlMigration(..)
+                                                , SqlPiece(..)
+                                                , parseSqlMigration
+                                                )
+import           Control.DeepSeq                ( NFData
+                                                , force
+                                                )
+import           Control.Exception              ( evaluate )
+import           Control.Monad                  ( forM
+                                                , forM_
+                                                , unless
+                                                )
+import           Criterion.Measurement          ( initializeTime
+                                                , measure
+                                                , secs
+                                                )
+import           Criterion.Measurement.Types    ( Benchmarkable(..)
+                                                , Measured(..)
+                                                , fromInt
+                                                )
+import           Data.Int                       ( Int64 )
+import           Data.Maybe                     ( fromMaybe )
+import           Data.Text                      ( Text )
+import qualified Data.Vector.Unboxed           as V
+import           Statistics.Regression          ( olsRegress )
+import           Streaming                      ( Of )
+import           Streaming.Prelude              ( Stream )
+import qualified Streaming.Prelude             as Streaming
+import qualified System.IO                     as IO
+import           Test.Hspec                     ( HasCallStack
+                                                , describe
+                                                , expectationFailure
+                                                , hspec
+                                                , it
+                                                , runIO
+                                                )
 
 manySelect1s :: Monad m => Int -> Stream (Of Text) m ()
 manySelect1s size = Streaming.replicate size "SELECT 1;"
 
 veryLargeCopy :: Monad m => Int -> Stream (Of Text) m ()
-veryLargeCopy size = Streaming.yield "COPY sometable FROM STDIN WITH (FORMAT csv);\n" >> Streaming.replicate size "4,Some name,2020-01-01\n" >> Streaming.yield "\\.\n"
+veryLargeCopy size =
+    Streaming.yield "COPY sometable FROM STDIN WITH (FORMAT csv);\n"
+        >> Streaming.replicate size "4,Some name,2020-01-01\n"
+        >> Streaming.yield "\\.\n"
 
 parseMig :: Stream (Of Text) IO () -> IO (Stream (Of SqlPiece) IO ())
 parseMig contents = do
-    Right (SqlMigration { migrationSql } :: SqlMigration IO) <- parseSqlMigration @IO "any-name.sql" (PureStream contents)
+    Right (SqlMigration { migrationSql } :: SqlMigration IO) <-
+        parseSqlMigration @IO "any-name.sql" (PureStream contents)
     case migrationSql of
-        UnparsedSql _ -> error "Error parsing SQL"
+        UnparsedSql   _ -> error "Error parsing SQL"
         WellParsedSql s -> pure s
 
+superForce :: NFData a => IO a -> IO a
+superForce vio = vio >>= evaluate . force
+
+bench :: NFData a => String -> IO a -> IO Measured
+bench name f = do
+    msr@Measured {..} <- fst <$> measure
+        Benchmarkable
+            {
+                            -- TODO: Do we need to performGC in between runs or does the framework do it for us?
+              allocEnv      = \_ -> pure ()
+            , cleanEnv      = \_ _ -> pure ()
+            , runRepeatedly = \_ n -> forM_ [1 .. n] $ const $ superForce f
+            , perRun        = True -- If True, `runRepeatedly` is called with `n=1`. Not sure why this exists, though.
+            }
+        10
+    putStrLn
+        $  "--- Benchmark "
+        ++ name
+        ++ ": Wall time="
+        ++ secs measTime
+        ++ ", peak memory usage: "
+        ++ show measPeakMbAllocated
+        ++ "MB."
+    pure msr
+
+shouldBeF :: HasCallStack => String -> Double -> Double -> Double -> IO ()
+shouldBeF errorMsg tolerance actual expected =
+    unless (abs (actual - expected) <= tolerance)
+        $  expectationFailure
+        $  errorMsg
+        ++ ": Expected a number within "
+        ++ show tolerance
+        ++ " of "
+        ++ show expected
+        ++ " but got "
+        ++ show actual
+
+-- | With data that has all y values being the same, r2 is often calculated to be one of [-Infinity, Infinity, NaN].
+-- I haven't seen it happen in other conditions yet, and https://github.com/haskell/statistics/issues/111 seems
+-- to be slightly related, so I'm assuming that's the only case when it happens.
+r2ShouldBe1 :: HasCallStack => String -> Double -> IO ()
+r2ShouldBe1 errorMsg r2 =
+    unless (isNaN r2 || isInfinite r2) $ shouldBeF errorMsg 0.001 r2 1
+
+-- | Checks that the measured quantities approximately form a line that passes
+-- through (0,0).
+mustFormALineWithOrigin
+    :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
+mustFormALineWithOrigin ms f = do
+    let xs = V.fromList $ map fst ms
+        ys = V.fromList $ map (f . snd) ms
+        (V.toList -> [_slope, yIntercept], r2) = olsRegress [xs] ys
+    -- print xs
+    -- print ys
+    -- print (_slope, yIntercept, r2)
+    shouldBeF "Line with origin (yIntercept)" 0.1 yIntercept 0
+    r2ShouldBe1 "Line with origin (r^2)" r2
+
+-- | Checks that the measured quantities approximately form a horizontal line.
+mustFormAHorizontalLine
+    :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
+mustFormAHorizontalLine ms f = do
+    let xs = V.fromList $ map fst ms
+        ys = V.fromList $ map (f . snd) ms
+        (V.toList -> [slope, _yIntercept], r2) = olsRegress [xs] ys
+    -- print xs
+    -- print ys
+    -- print (slope, _yIntercept, r2)
+    -- The error tolerance for the slope check is very stringent because so far
+    -- we only use it for the peak memory usage test, and those are Ints in Megabytes
+    -- so they really shouldn't vary unless we're very unlucky.
+    -- If more tests use this function, we should probably make the tolerance
+    -- an argument of it.
+    shouldBeF "Horizontal line (slope)" 0.000_01 slope 0
+    r2ShouldBe1 "Horizontal line (r^2)" r2
+
+fromGcInt :: Int64 -> Double
+fromGcInt =
+    fromIntegral
+        . fromMaybe
+              (error
+                  "GC stats not enabled. Are you running benchmarks with +RTS -T ?"
+              )
+        . fromInt
+
 main :: IO ()
-main = defaultMain [
-        bgroup "Streaming parser with 'SELECT 1;'" [
-            bench "10_000" $ nfIO $ parseMig (manySelect1s 10_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
-            , bench "100_000" $ nfIO $ parseMig (manySelect1s 100_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
-            , bench "1_000_000" $ nfIO $ parseMig (manySelect1s 1_000_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
-        ]
-        , bgroup "Streaming parser with COPY statement" [
-            bench "10_000" $ nfIO $ parseMig (veryLargeCopy 10_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
-            , bench "100_000" $ nfIO $ parseMig (veryLargeCopy 100_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
-            , bench "1_000_000" $ nfIO $ parseMig (veryLargeCopy 1_000_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
-        ]
-    ]
+main = do
+    IO.hSetBuffering IO.stdout IO.NoBuffering
+    IO.hSetBuffering IO.stderr IO.NoBuffering
+
+    -- initializeTime must run first: https://hackage.haskell.org/package/criterion-measurement-0.2.0.0/docs/Criterion-Measurement.html#v:initializeTime
+    initializeTime
+
+    hspec
+        $ describe
+              "Elapsed wall time must be linear with input size and max memory usage constant when streaming parse"
+        $ do
+        -- 1. Linear CPU time on input size means we're not accumulating anything
+        --    unreasonably when parsing in streaming fashion.
+        -- 2. Max memory usage constant is a must in a streaming parser as we should
+        --    be able to parse arbitrarily large SQL files.
+        --    Since peak MB allocated is an integer, however, it could be that it rounds to different numbers
+        --    on different runs despite the actual total max allocates bytes being very similar. This could
+        --    mess up our horizontal line check.
+              describe "Parsing several sequential 'SELECT 1;' statements" $ do
+                  rs :: [(Double, Measured)] <-
+                      runIO
+                      $ forM [10_000, 100_000, 500_000, 1_000_000]
+                      $ \n ->
+                            fmap (fromIntegral n, )
+                                $ bench ("SELECT 1 " ++ show n)
+                                $ do
+                              -- Uncomment the line below to make memory usage linear on input size
+                              -- and see memory usage rise and the test fail
+                              -- _ <- evaluate $ force [1 .. n]
+                                      parseMig (manySelect1s n)
+                                          >>= Streaming.any_
+                                                  (== CommentPiece
+                                                      "Not in the stream"
+                                                  )
+
+                  it "Elapsed wall time must linear wrt input size"
+                      $ mustFormALineWithOrigin rs measTime
+                  it
+                          "Peak memory usage must be constant regardless of input size"
+                      $ mustFormAHorizontalLine
+                            rs
+                            (fromGcInt . measPeakMbAllocated)
+
+              describe "Parsing COPY statement" $ do
+                  rs :: [(Double, Measured)] <-
+                      runIO
+                      $ forM [10_000, 100_000, 500_000, 1_000_000]
+                      $ \n ->
+                            fmap (fromIntegral n, )
+                                $ bench ("COPY " ++ show n)
+                                $ do
+                          -- Uncomment the line below to make memory usage linear on input size
+                          -- and see memory usage rise and the test fail
+                          -- _ <- evaluate $ force [1 .. n]
+                                      parseMig (veryLargeCopy n)
+                                          >>= Streaming.any_
+                                                  (== CommentPiece
+                                                      "Not in the stream"
+                                                  )
+
+                  it "Elapsed wall time must linear wrt input size"
+                      $ mustFormALineWithOrigin rs measTime
+                  it
+                          "Peak memory usage must be constant regardless of input size"
+                      $ mustFormAHorizontalLine
+                            rs
+                            (fromGcInt . measPeakMbAllocated)

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -53,207 +53,232 @@ manySelect1s size = Streaming.replicate size "SELECT 1;"
 
 veryLargeCopy :: Monad m => Int -> Stream (Of Text) m ()
 veryLargeCopy size =
-  Streaming.yield "COPY sometable FROM STDIN WITH (FORMAT csv);\n"
-    >> Streaming.replicate size "4,Some name,2020-01-01\n"
-    >> Streaming.yield "\\.\n"
+    Streaming.yield "COPY sometable FROM STDIN WITH (FORMAT csv);\n"
+        >> Streaming.replicate size "4,Some name,2020-01-01\n"
+        >> Streaming.yield "\\.\n"
 
 parseMig :: Stream (Of Text) IO () -> IO (Stream (Of SqlPiece) IO ())
 parseMig contents = do
-  Right (SqlMigration { migrationSql } :: SqlMigration IO) <-
-    parseSqlMigration @IO "any-name.sql" (PureStream contents)
-  case migrationSql of
-    UnparsedSql   _ -> error "Error parsing SQL"
-    WellParsedSql s -> pure s
+    Right (SqlMigration { migrationSql } :: SqlMigration IO) <-
+        parseSqlMigration @IO "any-name.sql" (PureStream contents)
+    case migrationSql of
+        UnparsedSql   _ -> error "Error parsing SQL"
+        WellParsedSql s -> pure s
 
 superForce :: NFData a => IO a -> IO a
 superForce vio = vio >>= evaluate . force
 
 bench :: NFData a => String -> IO a -> IO Measured
 bench name f = do
-  msr@Measured {..} <- fst <$> measure
-    Benchmarkable
-      {
-                          -- TODO: Do we need to performGC in between runs or does the framework do it for us?
-        allocEnv      = \_ -> pure ()
-      , cleanEnv      = \_ _ -> pure ()
-      , runRepeatedly = \_ n -> forM_ [1 .. n] $ const $ superForce f
-      , perRun        = True -- If True, `runRepeatedly` is called with `n=1`. Not sure why this exists, though.
-      }
-    10
-  putStrLn
-    $  "--- Benchmark "
-    ++ name
-    ++ ": Wall time="
-    ++ secs measTime
-    ++ ", peak memory usage="
-    ++ show measPeakMbAllocated
-    ++ " MB."
-  pure msr
+    msr@Measured {..} <- fst <$> measure
+        Benchmarkable
+            {
+                            -- TODO: Do we need to performGC in between runs or does the framework do it for us?
+              allocEnv      = \_ -> pure ()
+            , cleanEnv      = \_ _ -> pure ()
+            , runRepeatedly = \_ n -> forM_ [1 .. n] $ const $ superForce f
+            , perRun        = True -- If True, `runRepeatedly` is called with `n=1`. Not sure why this exists, though.
+            }
+        10
+    putStrLn
+        $  "--- Benchmark "
+        ++ name
+        ++ ": Wall time="
+        ++ secs measTime
+        ++ ", peak memory usage="
+        ++ show measPeakMbAllocated
+        ++ " MB."
+    pure msr
 
 shouldBeF :: HasCallStack => String -> Double -> Double -> Double -> IO ()
 shouldBeF errorMsg tolerance actual expected =
-  unless (abs (actual - expected) <= tolerance)
-    $  expectationFailure
-    $  errorMsg
-    ++ ": Expected a number within "
-    ++ show tolerance
-    ++ " of "
-    ++ show expected
-    ++ " but got "
-    ++ show actual
+    unless (abs (actual - expected) <= tolerance)
+        $  expectationFailure
+        $  errorMsg
+        ++ ": Expected a number within "
+        ++ show tolerance
+        ++ " of "
+        ++ show expected
+        ++ " but got "
+        ++ show actual
 
 -- | With data that has all y values being the same, r2 is often calculated to be one of [-Infinity, Infinity, NaN].
 -- I haven't seen it happen in other conditions yet, and https://github.com/haskell/statistics/issues/111 seems
 -- to be slightly related, so I'm assuming that's the only case when it happens.
 r2ShouldBe1 :: HasCallStack => String -> Double -> IO ()
 r2ShouldBe1 errorMsg r2 =
-  unless (isNaN r2 || isInfinite r2) $ shouldBeF errorMsg 0.001 r2 1
+    unless (isNaN r2 || isInfinite r2) $ shouldBeF errorMsg 0.001 r2 1
 
 -- | Checks that the measured quantities approximately form a line that passes
 -- through (0,0).
 mustFormALineWithOrigin
-  :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
+    :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
 mustFormALineWithOrigin ms f = do
-  let xs = V.fromList $ map fst ms
-      ys = V.fromList $ map (f . snd) ms
-      (V.toList -> [_slope, yIntercept], r2) = olsRegress [xs] ys
-  -- print xs
-  -- print ys
-  -- print (_slope, yIntercept, r2)
-  shouldBeF "Line with origin (yIntercept)" 0.1 yIntercept 0
-  r2ShouldBe1 "Line with origin (r^2)" r2
+    let xs = V.fromList $ map fst ms
+        ys = V.fromList $ map (f . snd) ms
+        (V.toList -> [_slope, yIntercept], r2) = olsRegress [xs] ys
+    -- print xs
+    -- print ys
+    -- print (_slope, yIntercept, r2)
+    shouldBeF "Line with origin (yIntercept)" 0.1 yIntercept 0
+    r2ShouldBe1 "Line with origin (r^2)" r2
 
 -- | Checks that the measured quantities approximately form a horizontal line.
 mustFormAHorizontalLine
-  :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
+    :: [(Double, Measured)] -> (Measured -> Double) -> IO ()
 mustFormAHorizontalLine ms f = do
-  let xs = V.fromList $ map fst ms
-      ys = V.fromList $ map (f . snd) ms
-      (V.toList -> [slope, _yIntercept], r2) = olsRegress [xs] ys
-  -- print xs
-  -- print ys
-  -- print (slope, _yIntercept, r2)
-  -- The error tolerance for the slope check is very stringent because so far
-  -- we only use it for the peak memory usage test, and those are Ints in Megabytes
-  -- so they really shouldn't vary unless we're very unlucky.
-  -- If more tests use this function, we should probably make the tolerance
-  -- an argument of it.
-  shouldBeF "Horizontal line (slope)" 0.000_01 slope 0
-  r2ShouldBe1 "Horizontal line (r^2)" r2
+    let xs = V.fromList $ map fst ms
+        ys = V.fromList $ map (f . snd) ms
+        (V.toList -> [slope, _yIntercept], r2) = olsRegress [xs] ys
+    -- print xs
+    -- print ys
+    -- print (slope, _yIntercept, r2)
+    -- The error tolerance for the slope check is very stringent because so far
+    -- we only use it for the peak memory usage test, and those are Ints in Megabytes
+    -- so they really shouldn't vary unless we're very unlucky.
+    -- If more tests use this function, we should probably make the tolerance
+    -- an argument of it.
+    shouldBeF "Horizontal line (slope)" 0.000_01 slope 0
+    r2ShouldBe1 "Horizontal line (r^2)" r2
 
 fromGcInt :: Int64 -> Double
 fromGcInt =
-  fromIntegral
-    . fromMaybe
-        (error "GC stats not enabled. Are you running benchmarks with +RTS -T ?"
-        )
-    . fromInt
+    fromIntegral
+        . fromMaybe
+              (error
+                  "GC stats not enabled. Are you running benchmarks with +RTS -T ?"
+              )
+        . fromInt
 
-avg :: [Double] -> Double
-avg [] = error "Average of empty list"
-avg xs = sum xs / fromIntegral (length xs) -- No need to fret with the implementation: our lists are small
+-- | Given a list with total of some measure (e.g. time) per number of runs, returns the average measure (e.g. time) per individual run.
+avgSamples :: (Measured -> Double) -> [(Double, Measured)] -> Double
+avgSamples _ [] = error "Average of empty list"
+avgSamples f xs = sum (map (f . snd) xs) / sum (map fst xs) -- No need to fret with the implementation: our lists are small
 
 data CurrentPerf = CurrentPerf
-  { select1TimeAndMemory :: (Double, Double)
-  , copyTimeAndMemory    :: (Double, Double)
-  }
-  deriving stock Generic
-  deriving anyclass FromJSON
+    { select1TimeAndMemory :: (Double, Double)
+    , copyTimeAndMemory    :: (Double, Double)
+    }
+    deriving stock Generic
+    deriving anyclass FromJSON
 
 main :: IO ()
 main = do
-  IO.hSetBuffering IO.stdout IO.NoBuffering
-  IO.hSetBuffering IO.stderr IO.NoBuffering
+    IO.hSetBuffering IO.stdout IO.NoBuffering
+    IO.hSetBuffering IO.stderr IO.NoBuffering
 
-  -- initializeTime must run first: https://hackage.haskell.org/package/criterion-measurement-0.2.0.0/docs/Criterion-Measurement.html#v:initializeTime
-  initializeTime
+    -- initializeTime must run first: https://hackage.haskell.org/package/criterion-measurement-0.2.0.0/docs/Criterion-Measurement.html#v:initializeTime
+    initializeTime
 
-  -- This is very ad-hoc, but variance in GitHub actions is much greater than on my own machine,
-  -- and I don't want to increase variance tolerance on my machine as it's good for it to be tight.
-  -- So we check if we're in CI and increase our tolerance for divergent perf numbers.
-  isCI <- isJust <$> lookupEnv "CI"
-  let expectedPerfPath :: FilePath = if isCI
-        then "bench/expected-perf/ci.json"
-        else "bench/expected-perf/local.json"
-  putStrLn $ "Reading expected performance numbers from " ++ expectedPerfPath
-  CurrentPerf {..} <-
-    either (error "Could not decode expected performance file") id
-      <$> eitherDecodeFileStrict expectedPerfPath
+    -- This is very ad-hoc, but variance in GitHub actions is much greater than on my own machine,
+    -- and I don't want to increase variance tolerance on my machine as it's good for it to be tight.
+    -- So we check if we're in CI and increase our tolerance for divergent perf numbers.
+    isCI <- isJust <$> lookupEnv "CI"
+    let expectedPerfPath :: FilePath = if isCI
+            then "bench/expected-perf/ci.json"
+            else "bench/expected-perf/local.json"
+    putStrLn $ "Reading expected performance numbers from " ++ expectedPerfPath
+    CurrentPerf {..} <-
+        either (error "Could not decode expected performance file") id
+            <$> eitherDecodeFileStrict expectedPerfPath
 
-  let (diffWallTimeTolerance, diffMaxMemTolerance) =
-        if isCI then (0.9, 1) else (0.5, 1)
+    let (diffWallTimeTolerance, diffMaxMemTolerance) =
+            if isCI then (1e-4, 1) else (1e-5, 1)
 
-  hspec
-    $ describe
-        "Elapsed wall time must be linear with input size and max memory usage constant when streaming parse"
-    $ do
-      -- 1. Linear CPU time on input size means we're not accumulating anything
-      --    unreasonably when parsing in streaming fashion.
-      -- 2. Max memory usage constant is a must in a streaming parser as we should
-      --    be able to parse arbitrarily large SQL files.
-      --    Since peak MB allocated is an integer, however, it could be that it rounds to different numbers
-      --    on different runs despite the actual total max allocates bytes being very similar. This could
-      --    mess up our horizontal line check.
-        describe "Parsing several sequential 'SELECT 1;' statements" $ do
-          rs :: [(Double, Measured)] <-
-            runIO $ forM [10_000, 100_000, 500_000, 1_000_000] $ \n ->
-              fmap (fromIntegral n, ) $ bench ("SELECT 1 " ++ show n) $ do
-                      -- Uncomment the line below to make memory usage linear on input size
-                      -- and see memory usage rise and the test fail
-                      -- _ <- evaluate $ force [1 .. n]
-                parseMig (manySelect1s n)
-                  >>= Streaming.any_ (== CommentPiece "Not in the stream")
+    hspec
+        $ describe
+              "Elapsed wall time must be linear with input size and max memory usage constant when streaming parse"
+        $ do
+        -- 1. Linear CPU time on input size means we're not accumulating anything
+        --    unreasonably when parsing in streaming fashion.
+        -- 2. Max memory usage constant is a must in a streaming parser as we should
+        --    be able to parse arbitrarily large SQL files.
+        --    Since peak MB allocated is an integer, however, it could be that it rounds to different numbers
+        --    on different runs despite the actual total max allocates bytes being very similar. This could
+        --    mess up our horizontal line check.
+              describe "Parsing several sequential 'SELECT 1;' statements" $ do
+                  rs :: [(Double, Measured)] <-
+                      runIO
+                      $ forM [10_000, 100_000, 500_000, 1_000_000]
+                      $ \n ->
+                            fmap (fromIntegral n, )
+                                $ bench ("SELECT 1 " ++ show n)
+                                $ do
+                              -- Uncomment the line below to make memory usage linear on input size
+                              -- and see memory usage rise and the test fail
+                              -- _ <- evaluate $ force [1 .. n]
+                                      parseMig (manySelect1s n)
+                                          >>= Streaming.any_
+                                                  (== CommentPiece
+                                                      "Not in the stream"
+                                                  )
 
-          it "Elapsed wall time must linear wrt input size"
-            $ mustFormALineWithOrigin rs measTime
-          it "Peak memory usage must be constant regardless of input size"
-            $ mustFormAHorizontalLine rs (fromGcInt . measPeakMbAllocated)
-          it "Must not be too different from expected performance" $ do
-            let measures = map snd rs
-            shouldBeF "Average wall time regression"
-                      diffWallTimeTolerance
-                      (avg (map measTime measures))
-                      (fst select1TimeAndMemory)
-            shouldBeF
-              "Max memory usage regression"
-              diffMaxMemTolerance
-              (maximum (map (fromGcInt . measPeakMbAllocated) measures))
-              (snd select1TimeAndMemory)
+                  it "Elapsed wall time must linear wrt input size"
+                      $ mustFormALineWithOrigin rs measTime
+                  it
+                          "Peak memory usage must be constant regardless of input size"
+                      $ mustFormAHorizontalLine
+                            rs
+                            (fromGcInt . measPeakMbAllocated)
+                  it "Must not be too different from expected performance" $ do
+                      shouldBeF "Average wall time regression"
+                                diffWallTimeTolerance
+                                (avgSamples measTime rs)
+                                (fst select1TimeAndMemory)
+                      shouldBeF
+                          "Max memory usage regression"
+                          diffMaxMemTolerance
+                          ( maximum
+                          $ map (fromGcInt . measPeakMbAllocated . snd) rs
+                          )
+                          (snd select1TimeAndMemory)
 
-        describe "Parsing COPY statement" $ do
-          rs :: [(Double, Measured)] <-
-            runIO
-            $ forM [100_000, 500_000, 1_000_000] -- Only large-ish sizes or less memory will be used and we want constant memory usage
-            $ \n -> fmap (fromIntegral n, ) $ bench ("COPY " ++ show n) $ do
-                  -- Uncomment the line below to make memory usage linear on input size
-                  -- and see memory usage rise and the test fail
-                  -- _ <- evaluate $ force [1 .. n]
-                parseMig (veryLargeCopy n)
-                  >>= Streaming.any_ (== CommentPiece "Not in the stream")
+              describe "Parsing COPY statement" $ do
+                  rs :: [(Double, Measured)] <-
+                      runIO
+                      $ forM [100_000, 500_000, 1_000_000] -- Only large-ish sizes or less memory will be used and we want constant memory usage
+                      $ \n ->
+                            fmap (fromIntegral n, )
+                                $ bench ("COPY " ++ show n)
+                                $ do
+                          -- Uncomment the line below to make memory usage linear on input size
+                          -- and see memory usage rise and the test fail
+                          -- _ <- evaluate $ force [1 .. n]
+                                      parseMig (veryLargeCopy n)
+                                          >>= Streaming.any_
+                                                  (== CommentPiece
+                                                      "Not in the stream"
+                                                  )
 
-          it "Elapsed wall time must linear wrt input size"
-            $ mustFormALineWithOrigin rs measTime
-          it "Peak memory usage must be constant regardless of input size"
-            $ mustFormAHorizontalLine rs (fromGcInt . measPeakMbAllocated)
+                  it "Elapsed wall time must linear wrt input size"
+                      $ mustFormALineWithOrigin rs measTime
+                  it
+                          "Peak memory usage must be constant regardless of input size"
+                      $ mustFormAHorizontalLine
+                            rs
+                            (fromGcInt . measPeakMbAllocated)
 
-          it "Must not be too different from expected performance" $ do
-            let measures = map snd rs
-            shouldBeF "Average wall time regression"
-                      diffWallTimeTolerance
-                      (avg (map measTime measures))
-                      (fst copyTimeAndMemory)
-            shouldBeF
-              "Max memory usage regression"
-              diffMaxMemTolerance
-              (maximum (map (fromGcInt . measPeakMbAllocated) measures))
-              (snd copyTimeAndMemory)
+                  it "Must not be too different from expected performance" $ do
+                      shouldBeF "Average wall time regression"
+                                diffWallTimeTolerance
+                                (avgSamples measTime rs)
+                                (fst copyTimeAndMemory)
+                      shouldBeF
+                          "Max memory usage regression"
+                          diffMaxMemTolerance
+                          ( maximum
+                          $ map (fromGcInt . measPeakMbAllocated . snd) rs
+                          )
+                          (snd copyTimeAndMemory)
 
-          it "Number of SQL pieces must be low to avoid too many round-trips"
-            $ do
-            -- The body of the contents inside COPY can be very large, so we don't want
-            -- small pieces coming out of the parser to avoid too many unnecessary round-trips.
-            -- Any changes to the parser will be detected by this test, but those should never
-            -- increase the number of parsed pieces too much.
-                len :: Int <-
-                  parseMig (veryLargeCopy 500_000) >>= Streaming.length_
-                len `shouldBe` 178
+                  it
+                          "Number of SQL pieces must be low to avoid too many round-trips"
+                      $ do
+                    -- The body of the contents inside COPY can be very large, so we don't want
+                    -- small pieces coming out of the parser to avoid too many unnecessary round-trips.
+                    -- Any changes to the parser will be detected by this test, but those should never
+                    -- increase the number of parsed pieces too much.
+                            len :: Int <-
+                                parseMig (veryLargeCopy 500_000)
+                                    >>= Streaming.length_
+                            len `shouldBe` 178

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE NumericUnderscores #-}
+module Main where
+
+import Codd.Parsing (SqlPiece (..), PureStream (..), SqlMigration (..), ParsedSql (..), parseSqlMigration)
+import Criterion.Main (defaultMain, bgroup, bench, nfIO)
+import Data.Text (Text)
+import Streaming (Of)
+import Streaming.Prelude (Stream)
+import qualified Streaming.Prelude as Streaming
+
+manySelect1s :: Monad m => Int -> Stream (Of Text) m ()
+manySelect1s size = Streaming.replicate size "SELECT 1;"
+
+veryLargeCopy :: Monad m => Int -> Stream (Of Text) m ()
+veryLargeCopy size = Streaming.yield "COPY sometable FROM STDIN WITH (FORMAT csv);\n" >> Streaming.replicate size "4,Some name,2020-01-01\n" >> Streaming.yield "\\.\n"
+
+parseMig :: Stream (Of Text) IO () -> IO (Stream (Of SqlPiece) IO ())
+parseMig contents = do
+    Right (SqlMigration { migrationSql } :: SqlMigration IO) <- parseSqlMigration @IO "any-name.sql" (PureStream contents)
+    case migrationSql of
+        UnparsedSql _ -> error "Error parsing SQL"
+        WellParsedSql s -> pure s
+
+main :: IO ()
+main = defaultMain [
+        bgroup "Streaming parser with 'SELECT 1;'" [
+            bench "10_000" $ nfIO $ parseMig (manySelect1s 10_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
+            , bench "100_000" $ nfIO $ parseMig (manySelect1s 100_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
+            , bench "1_000_000" $ nfIO $ parseMig (manySelect1s 1_000_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
+        ]
+        , bgroup "Streaming parser with COPY statement" [
+            bench "10_000" $ nfIO $ parseMig (veryLargeCopy 10_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
+            , bench "100_000" $ nfIO $ parseMig (veryLargeCopy 100_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
+            , bench "1_000_000" $ nfIO $ parseMig (veryLargeCopy 1_000_000) >>= Streaming.any_ (== CommentPiece "Not in the stream")
+        ]
+    ]

--- a/bench/expected-perf/.gitignore
+++ b/bench/expected-perf/.gitignore
@@ -1,0 +1,1 @@
+local.json

--- a/bench/expected-perf/ci.json
+++ b/bench/expected-perf/ci.json
@@ -1,0 +1,10 @@
+{
+    "select1TimeAndMemory": [
+        2.21,
+        2
+    ],
+    "copyTimeAndMemory": [
+        2.15,
+        2
+    ]
+}

--- a/bench/expected-perf/ci.json
+++ b/bench/expected-perf/ci.json
@@ -1,10 +1,10 @@
 {
     "select1TimeAndMemory": [
-        2.21,
+        4.17,
         2
     ],
     "copyTimeAndMemory": [
-        2.15,
+        3.94,
         2
     ]
 }

--- a/bench/expected-perf/ci.json
+++ b/bench/expected-perf/ci.json
@@ -1,10 +1,10 @@
 {
     "select1TimeAndMemory": [
-        4.17,
+        1e-5,
         2
     ],
     "copyTimeAndMemory": [
-        3.94,
-        2
+        7e-6,
+        4
     ]
 }

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,1 +1,0 @@
-tests: True

--- a/codd.cabal
+++ b/codd.cabal
@@ -147,6 +147,43 @@ executable codd
     , time
   default-language: Haskell2010
 
+benchmark codd-bench
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: bench
+  ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-qg -Wall -Wincomplete-uni-patterns -Wpartial-fields -Werror
+  default-extensions:
+      BangPatterns
+      DeriveAnyClass
+      DeriveFunctor
+      DeriveGeneric
+      DerivingStrategies
+      DerivingVia
+      LambdaCase
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
+      NamedFieldPuns
+      OverloadedStrings
+      TypeFamilies
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TupleSections
+      TypeApplications
+      TypeFamilyDependencies
+      ViewPatterns
+  build-depends:
+    base
+    , codd
+    , criterion
+    , streaming
+    , text
+  default-language: Haskell2010
+
 test-suite codd-test
   type: exitcode-stdio-1.0
   main-is: Main.hs

--- a/codd.cabal
+++ b/codd.cabal
@@ -151,7 +151,7 @@ benchmark codd-bench
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: bench
-  ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-qg -Wall -Wincomplete-uni-patterns -Wpartial-fields -Werror
+  ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-qg -with-rtsopts=-T -Wall -Wpartial-fields -Werror
   default-extensions:
       BangPatterns
       DeriveAnyClass
@@ -179,9 +179,15 @@ benchmark codd-bench
   build-depends:
     base
     , codd
-    , criterion
+    , criterion-measurement >= 0.2.0.0
+    , deepseq
+    , hspec
+    , hspec-core
+    , hspec-expectations
+    , statistics
     , streaming
     , text
+    , vector
   default-language: Haskell2010
 
 test-suite codd-test

--- a/codd.cabal
+++ b/codd.cabal
@@ -177,7 +177,8 @@ benchmark codd-bench
       TypeFamilyDependencies
       ViewPatterns
   build-depends:
-    base
+    aeson
+    , base
     , codd
     , criterion-measurement >= 0.2.0.0
     , deepseq

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,9 @@
                   inherit compiler-nix-name stackYaml;
 
                   modules = [{
+                    # Uncomment line below to be able to run cabal --enable-profiling
+                    # enableLibraryProfiling = true;
+
                     # Musl builds fail because postgresql-libpq requires pg_config in the path for its configure phase.
                     # See https://github.com/haskellari/postgresql-libpq/blob/master/Setup.hs#L65-L66
                     # packages.postgresql-libpq.components.library.build-tools =

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,8 @@
                   inherit compiler-nix-name stackYaml;
 
                   modules = [{
-                    # Uncomment line below to be able to run cabal --enable-profiling
-                    # enableLibraryProfiling = true;
+                    # Set to true to be able to run `cabal --enable-profiling`
+                    enableLibraryProfiling = false;
 
                     # Musl builds fail because postgresql-libpq requires pg_config in the path for its configure phase.
                     # See https://github.com/haskellari/postgresql-libpq/blob/master/Setup.hs#L65-L66

--- a/nix/prepare-cache-for-ci.sh
+++ b/nix/prepare-cache-for-ci.sh
@@ -2,5 +2,6 @@
 
 cachix watch-exec mzabani -- nix build --no-link .#codd:test:codd-test
 cachix watch-exec mzabani -- nix build --no-link .#packages.x86_64-linux.codd:lib:codd.doc
+cachix watch-exec mzabani -- nix build --no-link .#codd:bench:codd-bench
 cachix watch-exec mzabani -- nix build --no-link .#flakeAeson1.x86_64-linux.defaultPackage
 cachix watch-exec mzabani -- nix build --no-link .#dockerImage.x86_64-linux

--- a/src/Codd/Internal/MultiQueryStatement.hs
+++ b/src/Codd/Internal/MultiQueryStatement.hs
@@ -1,9 +1,9 @@
 module Codd.Internal.MultiQueryStatement
-  ( InTransaction(..)
-  , SqlStatementException(..)
-  , multiQueryStatement_
-  , runSingleStatementInternal_
-  ) where
+    ( InTransaction(..)
+    , SqlStatementException(..)
+    , multiQueryStatement_
+    , runSingleStatementInternal_
+    ) where
 
 import           Codd.Internal.Retry            ( retry_ )
 import           Codd.Parsing                   ( ParsedSql(..)
@@ -37,34 +37,34 @@ import           UnliftIO                       ( Exception
 -- unless there are explicit BEGIN/COMMIT commands included in the query string to divide it into multiple transactions."
 -- This creates problem for statements that can't run inside a single transaction (changing enums, creating dbs etc.)
 -- Because that seems to be at libpq level, we need to parse SQL (ugh..) and detect plPGSQL bodies and standard SQL to
--- split commands up.. I expect problems from this, really.
+-- split commands up.. tough situation.
 -- Note 1: Maybe alex works to translate psqlscan.l to Haskell? Seems like a rather complicated translation when I look at the source,
 -- and I don't know anything about lex/flex/alex.. also, we dong't need to be as good as psql in parsing SQL; we just need to find statement boundaries
 -- (psql counts parentheses, for instance) to split them up by that.
 -- Note 2: The CLI utility psql does the same and splits up commands before sending them to the server. See https://github.com/postgres/postgres/blob/master/src/fe_utils/psqlscan.l
 
 data SqlStatementException = SqlStatementException
-  { sqlStatement :: Text
-  , psimpleError :: DB.SqlError
-  }
-  deriving stock Show
+    { sqlStatement :: Text
+    , psimpleError :: DB.SqlError
+    }
+    deriving stock Show
 
 instance Exception SqlStatementException
 
--- | Runs SQL that could be either a row-returning or count-returning statement. Just lie postgresql-simple, throws exceptions in case of SQL errors.
+-- | Runs SQL that could be either a row-returning or count-returning statement. Just like postgresql-simple, throws exceptions in case of SQL errors.
 singleStatement_ :: MonadIO m => DB.Connection -> Text -> m ()
 singleStatement_ conn sql = do
-  res    <- liftIO $ PGInternal.exec conn $ encodeUtf8 sql
-  status <- liftIO $ PQ.resultStatus res
-  case status of
-    PQ.CommandOk -> pure ()
-    PQ.TuplesOk  -> pure ()
-    _ ->
-      liftIO
-        $ handle (throwIO . SqlStatementException sql)
-        $
-          -- Throw to catch and re-throw.. a bit nasty, but should be ok
-          PGInternal.throwResultError "singleStatement_" res status
+    res    <- liftIO $ PGInternal.exec conn $ encodeUtf8 sql
+    status <- liftIO $ PQ.resultStatus res
+    case status of
+        PQ.CommandOk -> pure ()
+        PQ.TuplesOk  -> pure ()
+        _ ->
+            liftIO
+                $ handle (throwIO . SqlStatementException sql)
+                $
+              -- Throw to catch and re-throw.. a bit nasty, but should be ok
+                  PGInternal.throwResultError "singleStatement_" res status
 
 data InTransaction = InTransaction | NotInTransaction RetryPolicy deriving stock (Eq)
 
@@ -73,35 +73,36 @@ data InTransaction = InTransaction | NotInTransaction RetryPolicy deriving stock
 --   2. If not in a transaction, then statements will be executed one-by-one and
 --      will be retried according to the retry policy.
 multiQueryStatement_
-  :: (MonadUnliftIO m, MonadIO m, MonadLogger m)
-  => InTransaction
-  -> DB.Connection
-  -> ParsedSql m
-  -> m ()
+    :: (MonadUnliftIO m, MonadIO m, MonadLogger m)
+    => InTransaction
+    -> DB.Connection
+    -> ParsedSql m
+    -> m ()
 multiQueryStatement_ inTxn conn sql = case (sql, inTxn) of
-  (UnparsedSql t, InTransaction) -> singleStatement_ conn t
-  (UnparsedSql t, NotInTransaction retryPol) ->
-    retry_ retryPol $ singleStatement_ conn t
-  (WellParsedSql stms, NotInTransaction retryPol) ->
-    -- We retry individual statements in no-txn migrations
-                                                     flip Streaming.mapM_ stms
-    $ \stm -> retry_ retryPol $ runSingleStatementInternal_ conn stm
-  (WellParsedSql stms, InTransaction) ->
-    -- We don't retry individual statements in in-txn migrations
-    flip Streaming.mapM_ stms $ \stm -> runSingleStatementInternal_ conn stm
+    (UnparsedSql t, InTransaction) -> singleStatement_ conn t
+    (UnparsedSql t, NotInTransaction retryPol) ->
+        retry_ retryPol $ singleStatement_ conn t
+    (WellParsedSql stms, NotInTransaction retryPol) ->
+      -- We retry individual statements in no-txn migrations
+        flip Streaming.mapM_ stms
+            $ \stm -> retry_ retryPol $ runSingleStatementInternal_ conn stm
+    (WellParsedSql stms, InTransaction) ->
+      -- We don't retry individual statements in in-txn migrations
+                                           flip Streaming.mapM_ stms
+        $ \stm -> runSingleStatementInternal_ conn stm
 
 runSingleStatementInternal_ :: MonadIO m => DB.Connection -> SqlPiece -> m ()
 runSingleStatementInternal_ _    (CommentPiece     _) = pure ()
 runSingleStatementInternal_ _    (WhiteSpacePiece  _) = pure ()
 runSingleStatementInternal_ conn (BeginTransaction s) = singleStatement_ conn s
 runSingleStatementInternal_ conn (CommitTransaction s) =
-  singleStatement_ conn s
+    singleStatement_ conn s
 runSingleStatementInternal_ conn (RollbackTransaction s) =
-  singleStatement_ conn s
+    singleStatement_ conn s
 runSingleStatementInternal_ conn (OtherSqlPiece s) = singleStatement_ conn s
 runSingleStatementInternal_ conn (CopyFromStdinStatement copyStm) =
-  liftIO $ DB.copy_ conn $ DB.Query (encodeUtf8 copyStm)
-runSingleStatementInternal_ conn (CopyFromStdinRow copyRow) =
-  liftIO $ DB.putCopyData conn $ encodeUtf8 copyRow
+    liftIO $ DB.copy_ conn $ DB.Query (encodeUtf8 copyStm)
+runSingleStatementInternal_ conn (CopyFromStdinRows copyRows) =
+    liftIO $ DB.putCopyData conn $ encodeUtf8 copyRows
 runSingleStatementInternal_ conn (CopyFromStdinEnd _) =
-  liftIO $ void $ DB.putCopyEnd conn
+    liftIO $ void $ DB.putCopyEnd conn

--- a/src/Codd/Parsing.hs
+++ b/src/Codd/Parsing.hs
@@ -1,34 +1,34 @@
 module Codd.Parsing
-  ( SqlMigration(..)
-  , AddedSqlMigration(..)
-  , CoddCommentParseResult(..)
-  , EnvVars(..)
-  , FileStream(..)
-  , SqlPiece(..)
-  , ParsedSql(..)
-  , PureStream(..)
-  , connStringParser
-  , hoistAddedSqlMigration
-  , isCommentPiece
-  , isTransactionEndingPiece
-  , isWhiteSpacePiece
-  , mapSqlMigration
-  , piecesToText
-  , sqlPieceText
-  , parsedSqlText
-  , parseSqlMigration
-  , parseWithEscapeCharProper
-  , parseAddedSqlMigration
-  , parseAndClassifyMigration
-  , parseMigrationTimestamp
-  , parseSqlPiecesStreaming
-  , toMigrationTimestamp
+    ( SqlMigration(..)
+    , AddedSqlMigration(..)
+    , CoddCommentParseResult(..)
+    , EnvVars(..)
+    , FileStream(..)
+    , SqlPiece(..)
+    , ParsedSql(..)
+    , PureStream(..)
+    , connStringParser
+    , hoistAddedSqlMigration
+    , isCommentPiece
+    , isTransactionEndingPiece
+    , isWhiteSpacePiece
+    , mapSqlMigration
+    , piecesToText
+    , sqlPieceText
+    , parsedSqlText
+    , parseSqlMigration
+    , parseWithEscapeCharProper
+    , parseAddedSqlMigration
+    , parseAndClassifyMigration
+    , parseMigrationTimestamp
+    , parseSqlPiecesStreaming
+    , toMigrationTimestamp
 
   -- Exported for tests
-  , ParserState(..)
-  , copyFromStdinAfterStatementParser
-  , parseSqlPiecesStreaming'
-  ) where
+    , ParserState(..)
+    , copyFromStdinAfterStatementParser
+    , parseSqlPiecesStreaming'
+    ) where
 
 import           Control.Applicative            ( (<|>)
                                                 , optional
@@ -112,22 +112,22 @@ data ParsedSql m =
   | WellParsedSql (Stream (Of SqlPiece) m ())
 
 data SqlMigration m = SqlMigration
-  { migrationName           :: FilePath
-  , migrationSql            :: ParsedSql m
-  , migrationInTxn          :: Bool
-  , migrationCustomConnInfo :: Maybe ConnectInfo
-  }
+    { migrationName           :: FilePath
+    , migrationSql            :: ParsedSql m
+    , migrationInTxn          :: Bool
+    , migrationCustomConnInfo :: Maybe ConnectInfo
+    }
 
 data AddedSqlMigration m = AddedSqlMigration
-  { addedSqlMig       :: SqlMigration m
-  , addedSqlTimestamp :: DB.UTCTimestamp
-  }
+    { addedSqlMig       :: SqlMigration m
+    , addedSqlTimestamp :: DB.UTCTimestamp
+    }
 
 data FileStream m = FileStream
-  { filePath   :: FilePath
-  , releaseKey :: ReleaseKey
-  , fileStream :: Stream (Of Text) m ()
-  }
+    { filePath   :: FilePath
+    , releaseKey :: ReleaseKey
+    , fileStream :: Stream (Of Text) m ()
+    }
 
 -- | Pure streams can be consumed as many times
 -- as necessary because consuming doesn't advance
@@ -142,48 +142,48 @@ class MigrationStream (m :: Type -> Type) (s :: Type) where
     migStream :: s -> Stream (Of Text) m ()
 
 instance Monad m => MigrationStream m (PureStream m) where
-  readFullContents PureStream { unPureStream } =
-    Streaming.fold_ (<>) "" id unPureStream
-  migStream PureStream { unPureStream } = unPureStream
+    readFullContents PureStream { unPureStream } =
+        Streaming.fold_ (<>) "" id unPureStream
+    migStream PureStream { unPureStream } = unPureStream
 
 instance MonadIO m => MigrationStream m (FileStream m) where
   -- | Reads entire file from disk again as so to
   -- be immune to the state of the Stream.
-  readFullContents FileStream { filePath } = liftIO $ Text.readFile filePath
-  migStream FileStream { fileStream } = fileStream
+    readFullContents FileStream { filePath } = liftIO $ Text.readFile filePath
+    migStream FileStream { fileStream } = fileStream
 
 -- TODO: This should probably not be in Parsing.hs
 hoistAddedSqlMigration
-  :: (Monad m, Monad n)
-  => (forall x . m x -> n x)
-  -> AddedSqlMigration m
-  -> AddedSqlMigration n
+    :: (Monad m, Monad n)
+    => (forall x . m x -> n x)
+    -> AddedSqlMigration m
+    -> AddedSqlMigration n
 hoistAddedSqlMigration f (AddedSqlMigration sqlMig tst) = AddedSqlMigration
-  (hoistSqlMig sqlMig)
-  tst
- where
-  hoistSqlMig mig = mig { migrationSql = hoistParsedSql $ migrationSql mig }
-  hoistParsedSql (UnparsedSql   t     ) = UnparsedSql t
-  hoistParsedSql (WellParsedSql stream) = WellParsedSql $ hoist f stream
+    (hoistSqlMig sqlMig)
+    tst
+  where
+    hoistSqlMig mig = mig { migrationSql = hoistParsedSql $ migrationSql mig }
+    hoistParsedSql (UnparsedSql   t     ) = UnparsedSql t
+    hoistParsedSql (WellParsedSql stream) = WellParsedSql $ hoist f stream
 
 mapSqlMigration
-  :: (SqlMigration m -> SqlMigration m)
-  -> AddedSqlMigration m
-  -> AddedSqlMigration m
+    :: (SqlMigration m -> SqlMigration m)
+    -> AddedSqlMigration m
+    -> AddedSqlMigration m
 mapSqlMigration f (AddedSqlMigration sqlMig tst) =
-  AddedSqlMigration (f sqlMig) tst
+    AddedSqlMigration (f sqlMig) tst
 
 data SectionOption = OptInTxn Bool | OptNoParse Bool
   deriving stock (Eq, Show)
 
-data SqlPiece = CommentPiece !Text | WhiteSpacePiece !Text | CopyFromStdinStatement !Text | CopyFromStdinRow !Text | CopyFromStdinEnd !Text | BeginTransaction !Text | RollbackTransaction !Text | CommitTransaction !Text | OtherSqlPiece !Text
+data SqlPiece = CommentPiece !Text | WhiteSpacePiece !Text | CopyFromStdinStatement !Text | CopyFromStdinRows !Text | CopyFromStdinEnd !Text | BeginTransaction !Text | RollbackTransaction !Text | CommitTransaction !Text | OtherSqlPiece !Text
   deriving stock (Show, Eq)
 
 data ParsingException = ParsingException
-  { sqlFragment :: Text
-  , errorMsg    :: String
-  }
-  deriving stock Show
+    { sqlFragment :: Text
+    , errorMsg    :: String
+    }
+    deriving stock Show
 
 instance Exception ParsingException
 
@@ -199,122 +199,130 @@ class EnvVars m where
     getEnvVars :: [Text] -> m (Map Text Text)
 
 instance EnvVars IO where
-  getEnvVars vars =
-    Map.fromList
-      <$> traverse
-            (\var -> lookupEnv (Text.unpack var)
-              >>= \mVal -> pure (var, maybe "" Text.pack mVal)
-            )
-            vars
+    getEnvVars vars =
+        Map.fromList
+            <$> traverse
+                    (\var -> lookupEnv (Text.unpack var)
+                        >>= \mVal -> pure (var, maybe "" Text.pack mVal)
+                    )
+                    vars
 
 instance (MonadTrans t, Monad m, EnvVars m) => EnvVars (t m) where
-  getEnvVars = lift . getEnvVars
+    getEnvVars = lift . getEnvVars
 
 {-# INLINE parseSqlPiecesStreaming #-} -- See Note [Inlining and specialization]
 -- | This should be a rough equivalent to `many sqlPieceParser` for Streams.
 parseSqlPiecesStreaming
-  :: forall m
-   . MonadThrow m
-  => Stream (Of Text) m ()
-  -> Stream (Of SqlPiece) m ()
+    :: forall m
+     . MonadThrow m
+    => Stream (Of Text) m ()
+    -> Stream (Of SqlPiece) m ()
 parseSqlPiecesStreaming = parseSqlPiecesStreaming' sqlPieceParser
 
 {-# INLINE parseSqlPiecesStreaming' #-} -- See Note [Inlining and specialization]
 -- | This should be a rough equivalent to `many parser` for Streams.
 parseSqlPiecesStreaming'
-  :: forall m
-   . MonadThrow m
-  => (ParserState -> Parser ([SqlPiece], ParserState))
-  -> Stream (Of Text) m ()
-  -> Stream (Of SqlPiece) m ()
+    :: forall m
+     . MonadThrow m
+    => (ParserState -> Parser ([SqlPiece], ParserState))
+    -> Stream (Of Text) m ()
+    -> Stream (Of SqlPiece) m ()
 parseSqlPiecesStreaming' parser contents = Streaming.concat parseResultsStream
   -- NOTE: attoparsec's `parseWith` looks at first glance like it might help, but
   -- the parser supplied to it is fixed, and we need a state-sensitive parser for each
   -- chunk, because chunks might be incomplete SQL pieces.
- where
-  mkErrorMsg errorMsg =
-    "An internal parsing error occurred. This is most likely a bug in codd. Please file a bug report.\
+  where
+    mkErrorMsg errorMsg =
+        "An internal parsing error occurred. This is most likely a bug in codd. Please file a bug report.\
     \ In the meantime, you can add this migration by writing \"-- codd: no-parse\" as its very first line.\
     \ The downside is this migration will be in-txn and COPY will not be supported. It will also be put in\
     \ memory all at once instead of being read and applied in streaming fashion.\
     \ The more detailed parsing error is: "
-      ++ errorMsg
+            ++ errorMsg
 
-  -- | Takes a parser result and does one of:
-  -- 1. Throws an error if it failed. Remember, we assume our SQL parsers can't fail.
-  -- 2. If one `SqlPiece`s was successfuly parsed, great. Because there could still be unconsumed text,
-  --    recursively parse that unconsumed text, and prepend the parsed `SqlPiece` to whatever the recursively
-  --    applied parser returns.
-  -- 3. If the parser didn't fail nor succeed, it wasn't yet fed sufficient input. This then returns
-  --    an empty list of `SqlPiece`s and a parser continuation.
-  -- In all cases, this returns the modified parser state too (one of `OutsideCopy` or `InsideCopy`).
-  handleParseResult
-    :: ParserState
-    -> Text
-    -> Maybe (Parsec.Result ([SqlPiece], ParserState))
-    -- ^ `Nothing` means this text piece is the very first to be parsed.
-    -- `Just` means this is the result of parsing the supplied text piece (second argument
-    -- to this function).
-    -> m
-         ( [SqlPiece]
-         , Maybe (Text -> Parsec.Result ([SqlPiece], ParserState))
-         , ParserState
-         )
-  handleParseResult !parserState !textPiece !mParseResult =
-    case mParseResult of
-      Nothing -> handleParseResult
-        parserState
-        textPiece
-        (Just $ Parsec.parse (parser parserState) textPiece)
-      Just (Parsec.Fail _ _ errorMsg) ->
-        throwM $ ParsingException textPiece $ mkErrorMsg errorMsg
-      Just (Parsec.Done unconsumedInput (sqlPieces, newParserState)) ->
-        if textPiece == ""
-            -- Special case: after consuming the empty string "" - which is interpreted as 
-            -- EOF -, it is possible unconsumed input remained from a previous partial parse.
-            -- Notice that unconsumed input at the end is probably garbage, but we still want to
-            -- be defensive and include it (in case there's a problem in the parsers).
-            -- So we can't forget to return that last unconsumed fragment in that case.
-          then pure
-            ( [ sqlPiece | sqlPiece <- sqlPieces, sqlPiece /= OtherSqlPiece "" ]
-            ++ [ OtherSqlPiece unconsumedInput | unconsumedInput /= "" ]
-            , Nothing
-            , newParserState
-            )
-          else first3 (sqlPieces ++) <$> handleParseResult
-            newParserState
-            unconsumedInput
-            (Just $ Parsec.parse (parser newParserState) unconsumedInput)
-      Just (Parsec.Partial nextContinue) ->
-        pure ([], Just nextContinue, parserState)
+    -- | Takes a parser result and does one of:
+    -- 1. Throws an error if it failed. Remember, we assume our SQL parsers can't fail.
+    -- 2. If one `SqlPiece`s was successfuly parsed, great. Because there could still be unconsumed text,
+    --    recursively parse that unconsumed text, and prepend the parsed `SqlPiece` to whatever the recursively
+    --    applied parser returns.
+    -- 3. If the parser didn't fail nor succeed, it wasn't yet fed sufficient input. This then returns
+    --    an empty list of `SqlPiece`s and a parser continuation.
+    -- In all cases, this returns the modified parser state too (one of `OutsideCopy` or `InsideCopy`).
+    handleParseResult
+        :: ParserState
+        -> Text
+        -> Maybe (Parsec.Result ([SqlPiece], ParserState))
+      -- ^ `Nothing` means this text piece is the very first to be parsed.
+      -- `Just` means this is the result of parsing the supplied text piece (second argument
+      -- to this function).
+        -> m
+               ( [SqlPiece]
+               , Maybe
+                     (Text -> Parsec.Result ([SqlPiece], ParserState))
+               , ParserState
+               )
+    handleParseResult !parserState !textPiece !mParseResult =
+        case mParseResult of
+            Nothing -> handleParseResult
+                parserState
+                textPiece
+                (Just $ Parsec.parse (parser parserState) textPiece)
+            Just (Parsec.Fail _ _ errorMsg) ->
+                throwM $ ParsingException textPiece $ mkErrorMsg errorMsg
+            Just (Parsec.Done unconsumedInput (sqlPieces, newParserState)) ->
+                if textPiece == ""
+                    -- Special case: after consuming the empty string "" - which is interpreted as 
+                    -- EOF -, it is possible unconsumed input remained from a previous partial parse.
+                    -- Notice that unconsumed input at the end is probably garbage, but we still want to
+                    -- be defensive and include it (in case there's a problem in the parsers).
+                    -- So we can't forget to return that last unconsumed fragment in that case.
+                    then pure
+                        ( [ sqlPiece
+                          | sqlPiece <- sqlPieces
+                          , sqlPiece /= OtherSqlPiece ""
+                          ]
+                        ++ [ OtherSqlPiece unconsumedInput
+                           | unconsumedInput /= ""
+                           ]
+                        , Nothing
+                        , newParserState
+                        )
+                    else first3 (sqlPieces ++) <$> handleParseResult
+                        newParserState
+                        unconsumedInput
+                        (Just $ Parsec.parse (parser newParserState)
+                                             unconsumedInput
+                        )
+            Just (Parsec.Partial nextContinue) ->
+                pure ([], Just nextContinue, parserState)
 
-  parseResultsStream :: Stream (Of [SqlPiece]) m ()
-  parseResultsStream =
-    Streaming.scanM
-        (\(_, !mContinue, !parserState) !textPiece -> handleParseResult
-          parserState
-          textPiece
-          (mContinue <*> Just textPiece)
-        )
-        (pure ([], Nothing, OutsideCopy))
-        (pure . fst3)
-    -- SQL files' last statement don't need to end with a semi-colon, and because of
-    -- that they could end up as a partial match in those cases.
-    -- When applying parsing continuations the empty string is used to signal/match
-    -- endOfInput. So we append a final empty string to the original stream to
-    -- parse the last SQL statement properly regardless of semi-colon.
-    -- Also, because empty strings are so special, we filter them out from the
-    -- input stream just in case.
-      $  Streaming.filter (/= "") contents
-      <> Streaming.yield ""
+    parseResultsStream :: Stream (Of [SqlPiece]) m ()
+    parseResultsStream =
+        Streaming.scanM
+                (\(_, !mContinue, !parserState) !textPiece -> handleParseResult
+                    parserState
+                    textPiece
+                    (mContinue <*> Just textPiece)
+                )
+                (pure ([], Nothing, OutsideCopy))
+                (pure . fst3)
+      -- SQL files' last statement don't need to end with a semi-colon, and because of
+      -- that they could end up as a partial match in those cases.
+      -- When applying parsing continuations the empty string is used to signal/match
+      -- endOfInput. So we append a final empty string to the original stream to
+      -- parse the last SQL statement properly regardless of semi-colon.
+      -- Also, because empty strings are so special, we filter them out from the
+      -- input stream just in case.
+            $  Streaming.filter (/= "") contents
+            <> Streaming.yield ""
 
-  fst3 (a, _, _) = a
-  first3 f (a, b, c) = (f a, b, c)
+    fst3 (a, _, _) = a
+    first3 f (a, b, c) = (f a, b, c)
 
 parsedSqlText :: Monad m => ParsedSql m -> m Text
 parsedSqlText (UnparsedSql t) = pure t
 parsedSqlText (WellParsedSql s) =
-  Streaming.fold_ (<>) "" id $ Streaming.map sqlPieceText s
+    Streaming.fold_ (<>) "" id $ Streaming.map sqlPieceText s
 
 sqlPieceText :: SqlPiece -> Text
 sqlPieceText (CommentPiece           s) = s
@@ -324,187 +332,212 @@ sqlPieceText (RollbackTransaction    s) = s
 sqlPieceText (CommitTransaction      s) = s
 sqlPieceText (OtherSqlPiece          s) = s
 sqlPieceText (CopyFromStdinStatement s) = s
-sqlPieceText (CopyFromStdinRow       s) = s
+sqlPieceText (CopyFromStdinRows      s) = s
 sqlPieceText (CopyFromStdinEnd       s) = s
 
 mapSqlPiece :: (Text -> Text) -> SqlPiece -> SqlPiece
 mapSqlPiece f = \case
-  CommentPiece           s -> CommentPiece (f s)
-  WhiteSpacePiece        s -> WhiteSpacePiece (f s)
-  BeginTransaction       s -> BeginTransaction (f s)
-  RollbackTransaction    s -> RollbackTransaction (f s)
-  CommitTransaction      s -> CommitTransaction (f s)
-  OtherSqlPiece          s -> OtherSqlPiece (f s)
-  CopyFromStdinStatement s -> CopyFromStdinStatement (f s)
-  CopyFromStdinRow       s -> CopyFromStdinRow (f s)
-  CopyFromStdinEnd       s -> CopyFromStdinEnd (f s)
+    CommentPiece           s -> CommentPiece (f s)
+    WhiteSpacePiece        s -> WhiteSpacePiece (f s)
+    BeginTransaction       s -> BeginTransaction (f s)
+    RollbackTransaction    s -> RollbackTransaction (f s)
+    CommitTransaction      s -> CommitTransaction (f s)
+    OtherSqlPiece          s -> OtherSqlPiece (f s)
+    CopyFromStdinStatement s -> CopyFromStdinStatement (f s)
+    CopyFromStdinRows      s -> CopyFromStdinRows (f s)
+    CopyFromStdinEnd       s -> CopyFromStdinEnd (f s)
 
 data ParserState = OutsideCopy | InsideCopy
   deriving stock (Eq, Show)
 
 sqlPieceParser :: ParserState -> Parser ([SqlPiece], ParserState)
 sqlPieceParser parserState = case parserState of
-  OutsideCopy -> first (: []) <$> outsideCopyParser
-  InsideCopy  -> copyFromStdinAfterStatementParser 65536
- where
-  outsideCopyParser =
-    (, OutsideCopy)
-      .   CommentPiece
-      <$> commentParser
-      <|> (, OutsideCopy)
-      .   WhiteSpacePiece
-      <$> takeWhile1
-            (\c -> Char.isSpace c || c == '\n' || c == '\r' || c == '\t')
-      <|> (, InsideCopy)
-      <$> copyFromStdinStatementParser
-      <|> (, OutsideCopy)
-      .   BeginTransaction
-      <$> beginTransactionParser
-      <|> (, OutsideCopy)
-      .   RollbackTransaction
-      <$> rollbackTransactionParser
-      <|> (, OutsideCopy)
-      .   CommitTransaction
-      <$> commitTransactionParser
-      <|> (, OutsideCopy)
-      .   OtherSqlPiece
-      <$> anySqlPieceParser
-  beginTransactionParser =
-    spaceSeparatedTokensToParser [CITextToken "BEGIN", AllUntilEndOfStatement]
-      <|> spaceSeparatedTokensToParser
-            [ CITextToken "START"
-            , CITextToken "TRANSACTION"
-            , AllUntilEndOfStatement
-            ]
-  rollbackTransactionParser = spaceSeparatedTokensToParser
-    [CITextToken "ROLLBACK", AllUntilEndOfStatement]
-  commitTransactionParser =
-    spaceSeparatedTokensToParser [CITextToken "COMMIT", AllUntilEndOfStatement]
-  anySqlPieceParser = spaceSeparatedTokensToParser [AllUntilEndOfStatement]
+    OutsideCopy -> first (: []) <$> outsideCopyParser
+    InsideCopy  -> copyFromStdinAfterStatementParser 65536
+  where
+    outsideCopyParser =
+        (, OutsideCopy)
+            .   CommentPiece
+            <$> commentParser
+            <|> (, OutsideCopy)
+            .   WhiteSpacePiece
+            <$> takeWhile1
+                    (\c -> Char.isSpace c || c == '\n' || c == '\r' || c == '\t'
+                    )
+            <|> (, InsideCopy)
+            <$> copyFromStdinStatementParser
+            <|> (, OutsideCopy)
+            .   BeginTransaction
+            <$> beginTransactionParser
+            <|> (, OutsideCopy)
+            .   RollbackTransaction
+            <$> rollbackTransactionParser
+            <|> (, OutsideCopy)
+            .   CommitTransaction
+            <$> commitTransactionParser
+            <|> (, OutsideCopy)
+            .   OtherSqlPiece
+            <$> anySqlPieceParser
+    beginTransactionParser =
+        spaceSeparatedTokensToParser
+                [CITextToken "BEGIN", AllUntilEndOfStatement]
+            <|> spaceSeparatedTokensToParser
+                    [ CITextToken "START"
+                    , CITextToken "TRANSACTION"
+                    , AllUntilEndOfStatement
+                    ]
+    rollbackTransactionParser = spaceSeparatedTokensToParser
+        [CITextToken "ROLLBACK", AllUntilEndOfStatement]
+    commitTransactionParser = spaceSeparatedTokensToParser
+        [CITextToken "COMMIT", AllUntilEndOfStatement]
+    anySqlPieceParser = spaceSeparatedTokensToParser [AllUntilEndOfStatement]
 
 data SqlToken = CITextToken !Text | SqlIdentifier | CommaSeparatedIdentifiers | Optional ![SqlToken] | CustomParserToken (Parser Text) | AllUntilEndOfStatement
 
 spaceSeparatedTokensToParser :: [SqlToken] -> Parser Text
 spaceSeparatedTokensToParser allTokens = case allTokens of
-  []                -> pure ""
-  [token1         ] -> parseToken token1
-  (token1 : tokens) -> do
-    s1     <- parseToken token1
-    spaces <- case (s1, token1) of
-      ("", Optional _) -> pure ""
-      _                -> commentOrSpaceParser True <|> pure ""
+    []                -> pure ""
+    [token1         ] -> parseToken token1
+    (token1 : tokens) -> do
+        s1     <- parseToken token1
+        spaces <- case (s1, token1) of
+            ("", Optional _) -> pure ""
+            _                -> commentOrSpaceParser True <|> pure ""
 
-    others <- spaceSeparatedTokensToParser tokens
-    pure $ s1 <> spaces <> others
- where
-  parseToken = \case
-    Optional          t -> spaceSeparatedTokensToParser t <|> pure ""
-    CITextToken       t -> asciiCI t
-    CustomParserToken p -> p
-    SqlIdentifier ->
-      let -- Identifiers can be in fully qualified form "database"."schema"."objectname",
-          -- with and without double quoting, e.g.: "schema".tablename
-          singleIdentifier =
-            blockParserOfType (== DoubleQuotedIdentifier) <|> takeWhile1
-              (\c -> not (Char.isSpace c) && c /= ',' && c /= '.' && c /= ')') -- TODO: What are the valid chars for identifiers?? Figure it out!!
-      in  listOfAtLeast1 [CustomParserToken singleIdentifier] "."
-    CommaSeparatedIdentifiers -> listOfAtLeast1 [SqlIdentifier] ","
-    AllUntilEndOfStatement    -> do
-      t1 <- takeWhile (\c -> not (isPossibleStartingChar c) && c /= ';')
-      mc <- peekChar
-      case mc of
-        Nothing  -> pure t1
-        Just ';' -> do
-          void $ char ';'
-          pure $ t1 <> ";"
-        Just _ -> do
-          t2 <- Text.concat . map snd <$> many1 blockParser <|> Parsec.take 1
-          -- After reading blocks or just a char, we still need to find a semi-colon to get a statement from start to finish!
-          t3 <- parseToken AllUntilEndOfStatement
-          pure $ t1 <> t2 <> t3
+        others <- spaceSeparatedTokensToParser tokens
+        pure $ s1 <> spaces <> others
+  where
+    parseToken = \case
+        Optional          t -> spaceSeparatedTokensToParser t <|> pure ""
+        CITextToken       t -> asciiCI t
+        CustomParserToken p -> p
+        SqlIdentifier ->
+            let -- Identifiers can be in fully qualified form "database"."schema"."objectname",
+                -- with and without double quoting, e.g.: "schema".tablename
+                singleIdentifier =
+                    blockParserOfType (== DoubleQuotedIdentifier)
+                        <|> takeWhile1
+                                (\c ->
+                                    not (Char.isSpace c)
+                                        && c
+                                        /= ','
+                                        && c
+                                        /= '.'
+                                        && c
+                                        /= ')'
+                                ) -- TODO: What are the valid chars for identifiers?? Figure it out!!
+            in  listOfAtLeast1 [CustomParserToken singleIdentifier] "."
+        CommaSeparatedIdentifiers -> listOfAtLeast1 [SqlIdentifier] ","
+        AllUntilEndOfStatement    -> do
+            t1 <- takeWhile (\c -> not (isPossibleStartingChar c) && c /= ';')
+            mc <- peekChar
+            case mc of
+                Nothing  -> pure t1
+                Just ';' -> do
+                    void $ char ';'
+                    pure $ t1 <> ";"
+                Just _ -> do
+                    t2 <-
+                        Text.concat
+                        .   map snd
+                        <$> many1 blockParser
+                        <|> Parsec.take 1
+                    -- After reading blocks or just a char, we still need to find a semi-colon to get a statement from start to finish!
+                    t3 <- parseToken AllUntilEndOfStatement
+                    pure $ t1 <> t2 <> t3
 
-  listOfAtLeast1 elementTokens separator = do
-    firstEl  <- spaceSeparatedTokensToParser elementTokens
-    -- We use pure "" only to allow for a space before the first separator..
-    otherEls <- Text.concat <$> many'
-      ( spaceSeparatedTokensToParser
-      $ CustomParserToken (pure "")
-      : CITextToken separator
-      : elementTokens
-      )
-    pure $ firstEl <> otherEls
+    listOfAtLeast1 elementTokens separator = do
+        firstEl  <- spaceSeparatedTokensToParser elementTokens
+        -- We use pure "" only to allow for a space before the first separator..
+        otherEls <- Text.concat <$> many'
+            ( spaceSeparatedTokensToParser
+            $ CustomParserToken (pure "")
+            : CITextToken separator
+            : elementTokens
+            )
+        pure $ firstEl <> otherEls
 
 -- Urgh.. parsing statements precisely would benefit a lot from importing the lex parser
 copyFromStdinStatementParser :: Parser SqlPiece
 copyFromStdinStatementParser = do
-  stmt <- spaceSeparatedTokensToParser
-    [ CITextToken "COPY"
-    , SqlIdentifier
-    , Optional
-      [CITextToken "(", Optional [CommaSeparatedIdentifiers], CITextToken ")"]
-    , CITextToken "FROM"
-    , CITextToken "STDIN"
-    , AllUntilEndOfStatement
-    ]
-  seol <- eol
-  pure $ CopyFromStdinStatement $ stmt <> seol
+    stmt <- spaceSeparatedTokensToParser
+        [ CITextToken "COPY"
+        , SqlIdentifier
+        , Optional
+            [ CITextToken "("
+            , Optional [CommaSeparatedIdentifiers]
+            , CITextToken ")"
+            ]
+        , CITextToken "FROM"
+        , CITextToken "STDIN"
+        , AllUntilEndOfStatement
+        ]
+    seol <- eol
+    pure $ CopyFromStdinStatement $ stmt <> seol
 
 -- | Parser to be used after "COPY FROM STDIN..." has been parsed with `copyFromStdinStatementParser`.
 copyFromStdinAfterStatementParser :: Int -> Parser ([SqlPiece], ParserState)
 copyFromStdinAfterStatementParser approxMaxChunkSize = do
-  when (approxMaxChunkSize <= 0)
-    $ error "approxMaxChunkSize must be strictly positive"
-  -- This stateful parser is tricky to get right but it's proven to be much faster than simpler
-  -- alternatives I've tried (e.g. taking lines and concatenating them was incredibly slow for some reason)
-  (contents, (_, _, terminatorLen)) <- Parsec.runScanner
-    (0 :: Int, 0 :: Int, 0 :: Int)
-    (\(lenTotalParsed, lenCurrentLine, lenTerminatorSoFar) c ->
-      if lenTotalParsed >= approxMaxChunkSize && lenCurrentLine == 0
-        then Nothing -- Only stop at the beginning of a new line
-        else if lenCurrentLine /= lenTerminatorSoFar && c == '\n'
-          then Just (1 + lenTotalParsed, 0, 0)
-          else if lenCurrentLine /= lenTerminatorSoFar
-            then Just (1 + lenTotalParsed, 1 + lenCurrentLine, 0)
-            else case (lenTerminatorSoFar, c) of
-              (0, '\\') -> Just (1 + lenTotalParsed, 1 + lenCurrentLine, 1)
-              (1, '.' ) -> Just (1 + lenTotalParsed, 1 + lenCurrentLine, 2)
-              (2, '\n') -> Just (1 + lenTotalParsed, 1 + lenCurrentLine, 3) -- Last char in terminator, but `Just` because it needs to be in the parsed contents
-              (3, _   ) -> Nothing -- Terminator with len=3 means it's been parsed, so end here.
-              (_, '\n') -> Just (1 + lenTotalParsed, 0, 0)
-              _         -> Just (1 + lenTotalParsed, 1 + lenCurrentLine, 0)
-    )
-  isEnd :: Bool <- Parsec.atEnd
-  let fullTerminator = "\\.\n"
-      eofTerminator  = "\\."
-      terminatorFound | terminatorLen == 3          = fullTerminator
-                      | isEnd && terminatorLen == 2 = eofTerminator
-                      | otherwise                   = ""
-      rows = Text.dropEnd terminatorLen contents
-  case (rows, terminatorFound) of
-    ("", "") -> pure ([], InsideCopy) -- This should be impossible
-    ("", _ ) -> pure ([CopyFromStdinEnd terminatorFound], OutsideCopy)
-    (_ , "") -> pure ([CopyFromStdinRow rows], InsideCopy)
-    (_ , _ ) -> pure
-      ([CopyFromStdinRow rows, CopyFromStdinEnd terminatorFound], OutsideCopy)
+    when (approxMaxChunkSize <= 0)
+        $ error "approxMaxChunkSize must be strictly positive"
+    -- This stateful parser is tricky to get right but it's proven to be much faster than simpler
+    -- alternatives I've tried (e.g. taking lines and concatenating them was incredibly slow for some reason)
+    (contents, (_, _, terminatorLen)) <- Parsec.runScanner
+        (0 :: Int, 0 :: Int, 0 :: Int)
+        (\(lenTotalParsed, lenCurrentLine, lenTerminatorSoFar) c ->
+            if lenTotalParsed >= approxMaxChunkSize && lenCurrentLine == 0
+                then Nothing -- Only stop at the beginning of a new line
+                else if lenCurrentLine /= lenTerminatorSoFar && c == '\n'
+                    then Just (1 + lenTotalParsed, 0, 0)
+                    else if lenCurrentLine /= lenTerminatorSoFar
+                        then Just (1 + lenTotalParsed, 1 + lenCurrentLine, 0)
+                        else case (lenTerminatorSoFar, c) of
+                            (0, '\\') ->
+                                Just (1 + lenTotalParsed, 1 + lenCurrentLine, 1)
+                            (1, '.') ->
+                                Just (1 + lenTotalParsed, 1 + lenCurrentLine, 2)
+                            (2, '\n') ->
+                                Just (1 + lenTotalParsed, 1 + lenCurrentLine, 3) -- Last char in terminator, but `Just` because it needs to be in the parsed contents
+                            (3, _   ) -> Nothing -- Terminator with len=3 means it's been parsed, so end here.
+                            (_, '\n') -> Just (1 + lenTotalParsed, 0, 0)
+                            _ ->
+                                Just (1 + lenTotalParsed, 1 + lenCurrentLine, 0)
+        )
+    isEnd :: Bool <- Parsec.atEnd
+    let fullTerminator = "\\.\n"
+        eofTerminator  = "\\."
+        terminatorFound | terminatorLen == 3          = fullTerminator
+                        | isEnd && terminatorLen == 2 = eofTerminator
+                        | otherwise                   = ""
+        rows = Text.dropEnd terminatorLen contents
+    case (rows, terminatorFound) of
+        ("", "") -> pure ([], InsideCopy) -- This should be impossible
+        ("", _ ) -> pure ([CopyFromStdinEnd terminatorFound], OutsideCopy)
+        (_ , "") -> pure ([CopyFromStdinRows rows], InsideCopy)
+        (_ , _ ) -> pure
+            ( [CopyFromStdinRows rows, CopyFromStdinEnd terminatorFound]
+            , OutsideCopy
+            )
 
 -- | Parses 0 or more consecutive white-space or comments
 commentOrSpaceParser :: Bool -> Parser Text
 commentOrSpaceParser atLeastOne = if atLeastOne
-  then Text.concat <$> many1 (commentParser <|> takeWhile1 Char.isSpace)
-  else Text.concat <$> many' (commentParser <|> takeWhile1 Char.isSpace)
+    then Text.concat <$> many1 (commentParser <|> takeWhile1 Char.isSpace)
+    else Text.concat <$> many' (commentParser <|> takeWhile1 Char.isSpace)
 
 commentParser :: Parser Text
 commentParser = do
-  (commentType, commentInit) <-
-    (DoubleDashComment, ) <$> string "--" <|> (CStyleComment, ) <$> string "/*"
-  bRemaining <- blockInnerContentsParser commentType
-  pure $ commentInit <> bRemaining
+    (commentType, commentInit) <-
+        (DoubleDashComment, ) <$> string "--" <|> (CStyleComment, ) <$> string
+            "/*"
+    bRemaining <- blockInnerContentsParser commentType
+    pure $ commentInit <> bRemaining
 
 data BlockType = DoubleDashComment | CStyleComment | DollarQuotedBlock !Text | DoubleQuotedIdentifier | SingleQuotedString deriving stock (Show, Eq)
 
 isPossibleStartingChar :: Char -> Bool
 isPossibleStartingChar c =
-  c == '-' || c == '/' || c == '"' || c == '$' || c == '\''
+    c == '-' || c == '/' || c == '"' || c == '$' || c == '\''
 
 isPossibleEndingChar :: BlockType -> Char -> Bool
 isPossibleEndingChar DoubleDashComment      c = c == '\n'
@@ -515,64 +548,64 @@ isPossibleEndingChar SingleQuotedString     c = c == '\''
 
 blockBeginParser :: Parser (BlockType, Text)
 blockBeginParser =
-  (DoubleDashComment, )
-    <$> string "--"
-    <|> (CStyleComment, )
-    <$> string "/*"
-    <|> dollarBlockParser
-    <|> (DoubleQuotedIdentifier, )
-    <$> string "\""
-    <|> (SingleQuotedString, )
-    <$> string "'"
- where
-  dollarBlockParser = do
-    void $ char '$'
-    b <- takeWhile (/= '$')
-    void $ char '$'
-    let tb = "$" <> b <> "$"
-    pure (DollarQuotedBlock tb, tb)
+    (DoubleDashComment, )
+        <$> string "--"
+        <|> (CStyleComment, )
+        <$> string "/*"
+        <|> dollarBlockParser
+        <|> (DoubleQuotedIdentifier, )
+        <$> string "\""
+        <|> (SingleQuotedString, )
+        <$> string "'"
+  where
+    dollarBlockParser = do
+        void $ char '$'
+        b <- takeWhile (/= '$')
+        void $ char '$'
+        let tb = "$" <> b <> "$"
+        pure (DollarQuotedBlock tb, tb)
 
 blockEndingParser :: BlockType -> Parser Text
 blockEndingParser = \case
-  DoubleDashComment      -> eol <|> ("" <$ endOfInput)
-  CStyleComment          -> string "*/"
-  DollarQuotedBlock q    -> asciiCI q -- TODO: will asciiCI break for invalid ascii chars?
-  DoubleQuotedIdentifier -> string "\""
-  SingleQuotedString     -> string "'"
+    DoubleDashComment      -> eol <|> ("" <$ endOfInput)
+    CStyleComment          -> string "*/"
+    DollarQuotedBlock q    -> asciiCI q -- TODO: will asciiCI break for invalid ascii chars?
+    DoubleQuotedIdentifier -> string "\""
+    SingleQuotedString     -> string "'"
 
 eol :: Parser Text
 eol = string "\n" <|> string "\r\n"
 
 blockParser :: Parser (BlockType, Text)
 blockParser = do
-  (bt, bBegin) <- blockBeginParser
-  bRemaining   <- blockInnerContentsParser bt
-  pure (bt, bBegin <> bRemaining)
+    (bt, bBegin) <- blockBeginParser
+    bRemaining   <- blockInnerContentsParser bt
+    pure (bt, bBegin <> bRemaining)
 
 blockParserOfType :: (BlockType -> Bool) -> Parser Text
 blockParserOfType p = do
-  (bt, c) <- blockParser
-  guard $ p bt
-  pure c
+    (bt, c) <- blockParser
+    guard $ p bt
+    pure c
 
 blockInnerContentsParser :: BlockType -> Parser Text
 blockInnerContentsParser bt = do
-  t <- case bt of
-    SingleQuotedString     -> parseWithEscapeCharPreserve (== '\'') -- '' escaping is not to be explicitly implemented, but this parser understands it as two consecutive strings, and that's good enough for now
-    DoubleQuotedIdentifier -> parseWithEscapeCharPreserve (== '"') -- "" escaping seems to be the same as above..
-    _                      -> takeWhile (not . isPossibleEndingChar bt)
-  done <- atEnd
-  if done
-    then pure t
-    else do
-      mEndingQuote <- optional (blockEndingParser bt)
-      case mEndingQuote of
-        Nothing -> do
-          -- Could mean we found e.g. '*' inside a C-Style comment block, but not followed by '/'
-          c      <- anyChar
-          remain <- blockInnerContentsParser bt
-          pure $ Text.snoc t c <> remain
-        Just endingQuote -> pure $ t <> endingQuote
+    t <- case bt of
+        SingleQuotedString     -> parseWithEscapeCharPreserve (== '\'') -- '' escaping is not to be explicitly implemented, but this parser understands it as two consecutive strings, and that's good enough for now
+        DoubleQuotedIdentifier -> parseWithEscapeCharPreserve (== '"') -- "" escaping seems to be the same as above..
+        _                      -> takeWhile (not . isPossibleEndingChar bt)
+    done <- atEnd
+    if done
+        then pure t
+        else do
+            mEndingQuote <- optional (blockEndingParser bt)
+            case mEndingQuote of
+                Nothing -> do
+                  -- Could mean we found e.g. '*' inside a C-Style comment block, but not followed by '/'
+                    c      <- anyChar
+                    remain <- blockInnerContentsParser bt
+                    pure $ Text.snoc t c <> remain
+                Just endingQuote -> pure $ t <> endingQuote
 
 -- | Parses a value using backslash as an escape char for any char that matches
 -- the supplied predicate. Does not consume the ending char and RETURNS any
@@ -581,14 +614,14 @@ blockInnerContentsParser bt = do
 -- This function is useful if you want the original parsed contents.
 parseWithEscapeCharPreserve :: (Char -> Bool) -> Parser Text
 parseWithEscapeCharPreserve untilc = do
-  cs       <- Parsec.takeWhile (\c -> c /= '\\' && not (untilc c))
-  nextChar <- peekChar
-  case nextChar of
-    Just '\\' -> do
-      c    <- Parsec.take 2
-      rest <- parseWithEscapeCharPreserve untilc
-      pure $ cs <> c <> rest
-    _ -> pure cs
+    cs       <- Parsec.takeWhile (\c -> c /= '\\' && not (untilc c))
+    nextChar <- peekChar
+    case nextChar of
+        Just '\\' -> do
+            c    <- Parsec.take 2
+            rest <- parseWithEscapeCharPreserve untilc
+            pure $ cs <> c <> rest
+        _ -> pure cs
 
 -- | Parses a value using backslash as an escape char for any char that matches
 -- the supplied predicate. Stops at and does not consume the first predicate-passing
@@ -596,16 +629,16 @@ parseWithEscapeCharPreserve untilc = do
 -- as one would expect.
 parseWithEscapeCharProper :: (Char -> Bool) -> Parser Text
 parseWithEscapeCharProper untilc = do
-  cs       <- Parsec.takeWhile (\c -> c /= '\\' && not (untilc c))
-  nextChar <- peekChar
-  case nextChar of
-    Nothing   -> pure cs
-    Just '\\' -> do
-      void $ char '\\'
-      c    <- Parsec.take 1
-      rest <- parseWithEscapeCharProper untilc
-      pure $ cs <> c <> rest
-    Just _ -> pure cs
+    cs       <- Parsec.takeWhile (\c -> c /= '\\' && not (untilc c))
+    nextChar <- peekChar
+    case nextChar of
+        Nothing   -> pure cs
+        Just '\\' -> do
+            void $ char '\\'
+            c    <- Parsec.take 1
+            rest <- parseWithEscapeCharProper untilc
+            pure $ cs <> c <> rest
+        Just _ -> pure cs
 
 eitherToMay :: Either a b -> Maybe b
 eitherToMay (Left  _) = Nothing
@@ -615,153 +648,160 @@ eitherToMay (Right v) = Just v
 -- The difference here is that URIs with a query string or with a fragment are not allowed.
 uriConnParser :: Text -> Either String ConnectInfo
 uriConnParser line = runIdentity $ runExceptT @String @_ @ConnectInfo $ do
-  case parseURI (Text.unpack line) of
-    Nothing       -> throwE "Connection string is not a URI"
-    Just URI {..} -> do
-      when
-          (         Text.toLower (Text.pack uriScheme)
-          `notElem` ["postgres:", "postgresql:"]
-          )
-        $ throwE
-            "Connection string's URI scheme must be 'postgres' or 'postgresql'"
-      case uriAuthority of
-        Nothing ->
-          throwE "Connection string must contain at least user and host"
-        Just URIAuth {..} -> do
-          let connectDatabase = unEscapeString $ trimFirst '/' uriPath
-              hasQueryString  = not $ null uriQuery
-              hasFragment     = not $ null uriFragment
-          when (null connectDatabase)
-            $ throwE "Connection string must contain a database name"
-          when (hasQueryString || hasFragment)
-            $ throwE
-                "Custom parameters are not supported in connection strings. Make sure your connection URI does not have a query string or query fragment"
+    case parseURI (Text.unpack line) of
+        Nothing       -> throwE "Connection string is not a URI"
+        Just URI {..} -> do
+            when
+                    (         Text.toLower (Text.pack uriScheme)
+                    `notElem` ["postgres:", "postgresql:"]
+                    )
+                $ throwE
+                      "Connection string's URI scheme must be 'postgres' or 'postgresql'"
+            case uriAuthority of
+                Nothing -> throwE
+                    "Connection string must contain at least user and host"
+                Just URIAuth {..} -> do
+                    let connectDatabase =
+                            unEscapeString $ trimFirst '/' uriPath
+                        hasQueryString = not $ null uriQuery
+                        hasFragment    = not $ null uriFragment
+                    when (null connectDatabase) $ throwE
+                        "Connection string must contain a database name"
+                    when (hasQueryString || hasFragment)
+                        $ throwE
+                              "Custom parameters are not supported in connection strings. Make sure your connection URI does not have a query string or query fragment"
 
-          -- Ports are not mandatory and are defaulted to 5432 when not present
-          let port = if null uriPort then Just 5432 else Nothing
-          case
-              port <|> eitherToMay
-                (parseOnly (Parsec.decimal <* endOfInput)
-                           (Text.pack $ trimFirst ':' uriPort)
-                )
-            of
-              Nothing          -> throwE "Invalid port in connection string"
-              Just connectPort -> do
-                let
-                  (unEscapeString . trimLast '@' -> connectUser, unEscapeString . trimLast '@' . trimFirst ':' -> connectPassword)
-                    = break (== ':') uriUserInfo
-                pure ConnectInfo
-                  { connectHost     = unEscapeString $ unescapeIPv6 uriRegName
-                  , connectPort
-                  , connectUser
-                  , connectPassword
-                  , connectDatabase
-                  }
- where
-  unescapeIPv6 :: String -> String
-  unescapeIPv6 = trimFirst '[' . trimLast ']'
+                    -- Ports are not mandatory and are defaulted to 5432 when not present
+                    let port = if null uriPort then Just 5432 else Nothing
+                    case
+                            port <|> eitherToMay
+                                (parseOnly
+                                    (Parsec.decimal <* endOfInput)
+                                    (Text.pack $ trimFirst ':' uriPort)
+                                )
+                        of
+                            Nothing ->
+                                throwE "Invalid port in connection string"
+                            Just connectPort -> do
+                                let
+                                    (unEscapeString . trimLast '@' -> connectUser, unEscapeString . trimLast '@' . trimFirst ':' -> connectPassword)
+                                        = break (== ':') uriUserInfo
+                                pure ConnectInfo
+                                    { connectHost     = unEscapeString
+                                        $ unescapeIPv6 uriRegName
+                                    , connectPort
+                                    , connectUser
+                                    , connectPassword
+                                    , connectDatabase
+                                    }
+  where
+    unescapeIPv6 :: String -> String
+    unescapeIPv6 = trimFirst '[' . trimLast ']'
 
-  trimFirst :: Char -> String -> String
-  trimFirst c s@(c1 : cs) = if c == c1 then cs else s
-  trimFirst _ s           = s
+    trimFirst :: Char -> String -> String
+    trimFirst c s@(c1 : cs) = if c == c1 then cs else s
+    trimFirst _ s           = s
 
-  trimLast :: Char -> String -> String
-  trimLast c s = case Text.unsnoc $ Text.pack s of
-    Nothing            -> s
-    Just (t, lastChar) -> if lastChar == c then Text.unpack t else s
+    trimLast :: Char -> String -> String
+    trimLast c s = case Text.unsnoc $ Text.pack s of
+        Nothing            -> s
+        Just (t, lastChar) -> if lastChar == c then Text.unpack t else s
 
 
 keywordValueConnParser :: Text -> Either String ConnectInfo
 keywordValueConnParser line = runIdentity $ runExceptT $ do
-  kvs <- sortOn fst <$> parseOrFail
-    (singleKeyVal `Parsec.sepBy` takeWhile1 (== ' '))
-    (Text.strip line)
-    "Invalid connection string"
-  -- TODO: Error if there are other keys that we're not using present.
-  ConnectInfo
-    <$> getVal "host"     Nothing     txtToString    kvs
-    <*> getVal "port"     (Just 5432) Parsec.decimal kvs
-    <*> getVal "user"     Nothing     txtToString    kvs
-    <*> getVal "password" (Just "")   txtToString    kvs
-    <*> getVal "dbname"   Nothing     txtToString    kvs
- where
-  getVal key def parser pairs =
-    case (map snd $ filter ((== key) . fst) pairs, def) of
-      ([], Nothing) ->
-        throwE
-          $  "Connection string must contain a value for '"
-          <> Text.unpack key
-          <> "'"
-      ([], Just v) -> pure v
-      ([vt], _) ->
-        parseOrFail parser vt
-          $  "Connection string key '"
-          <> Text.unpack key
-          <> "' is in an unrecognizable format"
-      _ ->
-        throwE
-          $  "Duplicate key '"
-          <> Text.unpack key
-          <> "' found in connection string."
+    kvs <- sortOn fst <$> parseOrFail
+        (singleKeyVal `Parsec.sepBy` takeWhile1 (== ' '))
+        (Text.strip line)
+        "Invalid connection string"
+    -- TODO: Error if there are other keys that we're not using present.
+    ConnectInfo
+        <$> getVal "host"     Nothing     txtToString    kvs
+        <*> getVal "port"     (Just 5432) Parsec.decimal kvs
+        <*> getVal "user"     Nothing     txtToString    kvs
+        <*> getVal "password" (Just "")   txtToString    kvs
+        <*> getVal "dbname"   Nothing     txtToString    kvs
+  where
+    getVal key def parser pairs =
+        case (map snd $ filter ((== key) . fst) pairs, def) of
+            ([], Nothing) ->
+                throwE
+                    $  "Connection string must contain a value for '"
+                    <> Text.unpack key
+                    <> "'"
+            ([], Just v) -> pure v
+            ([vt], _) ->
+                parseOrFail parser vt
+                    $  "Connection string key '"
+                    <> Text.unpack key
+                    <> "' is in an unrecognizable format"
+            _ ->
+                throwE
+                    $  "Duplicate key '"
+                    <> Text.unpack key
+                    <> "' found in connection string."
 
-  txtToString = Text.unpack <$> Parsec.takeText
-  parseOrFail parser txt errorMsg =
-    case parseOnly (parser <* endOfInput) txt of
-      Left  _ -> throwE errorMsg
-      Right v -> pure v
+    txtToString = Text.unpack <$> Parsec.takeText
+    parseOrFail parser txt errorMsg =
+        case parseOnly (parser <* endOfInput) txt of
+            Left  _ -> throwE errorMsg
+            Right v -> pure v
 
-  singleKeyVal = do
-    key <- takeWhile1 (\c -> c /= ' ' && c /= '=')
-    skipJustSpace
-    void $ char '='
-    skipJustSpace
-    value <-
-      takeQuotedString
-      <|> parseWithEscapeCharProper (\c -> c == ' ' || c == '\'' || c == '\\')
-      <|> pure ""
-    pure (key, value)
+    singleKeyVal = do
+        key <- takeWhile1 (\c -> c /= ' ' && c /= '=')
+        skipJustSpace
+        void $ char '='
+        skipJustSpace
+        value <-
+            takeQuotedString
+            <|> parseWithEscapeCharProper
+                    (\c -> c == ' ' || c == '\'' || c == '\\')
+            <|> pure ""
+        pure (key, value)
 
-  takeQuotedString = do
-    void $ char '\''
-    s <- parseWithEscapeCharProper (== '\'')
-    void $ char '\''
-    pure s
+    takeQuotedString = do
+        void $ char '\''
+        s <- parseWithEscapeCharProper (== '\'')
+        void $ char '\''
+        pure s
 
 -- | Parses a string in one of libpq allowed formats. See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING.
 -- The difference here is that only a subset of all connection parameters are allowed.
 connStringParser :: Parser ConnectInfo
 connStringParser = do
-  connStr <- Parsec.takeWhile1 (not . Parsec.isEndOfLine)
-    <|> fail "Empty connection string"
-  -- Very poor connection string type handling here
-  let connStrParser =
-        if ("postgres://" `Text.isPrefixOf` Text.toLower connStr)
-             || ("postgresql://" `Text.isPrefixOf` Text.toLower connStr)
-          then uriConnParser
-          else keywordValueConnParser
-  case connStrParser connStr of
-    Left err ->
-      fail
-        $ "Connection string is not a valid libpq connection string. A valid libpq connection string is either in the format 'postgres://username[:password]@host:port/database_name', with URI-encoded (percent-encoded) components except for the host and bracket-surround IPv6 addresses, or in the keyword value pairs format, e.g. 'dbname=database_name host=localhost user=postgres' with escaping for spaces, quotes or empty values. More info at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING. Specific error: "
-        <> err
-    Right c -> pure c
+    connStr <- Parsec.takeWhile1 (not . Parsec.isEndOfLine)
+        <|> fail "Empty connection string"
+    -- Very poor connection string type handling here
+    let connStrParser =
+            if ("postgres://" `Text.isPrefixOf` Text.toLower connStr)
+                || ("postgresql://" `Text.isPrefixOf` Text.toLower connStr)
+            then
+                uriConnParser
+            else
+                keywordValueConnParser
+    case connStrParser connStr of
+        Left err ->
+            fail
+                $ "Connection string is not a valid libpq connection string. A valid libpq connection string is either in the format 'postgres://username[:password]@host:port/database_name', with URI-encoded (percent-encoded) components except for the host and bracket-surround IPv6 addresses, or in the keyword value pairs format, e.g. 'dbname=database_name host=localhost user=postgres' with escaping for spaces, quotes or empty values. More info at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING. Specific error: "
+                <> err
+        Right c -> pure c
 
 
 optionParser :: Parser SectionOption
 optionParser = do
-  skipJustSpace
-  x <-
-    inTxn
-    <|> noTxn
-    <|> noParse
-    <|> fail
-          "Valid options after '-- codd:' are 'in-txn', 'no-txn' or 'no-parse' (the last implies in-txn)"
-  skipJustSpace
-  return x
- where
-  inTxn   = string "in-txn" >> pure (OptInTxn True)
-  noTxn   = string "no-txn" >> pure (OptInTxn False)
-  noParse = string "no-parse" >> pure (OptNoParse True)
+    skipJustSpace
+    x <-
+        inTxn
+        <|> noTxn
+        <|> noParse
+        <|> fail
+                "Valid options after '-- codd:' are 'in-txn', 'no-txn' or 'no-parse' (the last implies in-txn)"
+    skipJustSpace
+    return x
+  where
+    inTxn   = string "in-txn" >> pure (OptInTxn True)
+    noTxn   = string "no-txn" >> pure (OptInTxn False)
+    noParse = string "no-parse" >> pure (OptNoParse True)
 
 
 skipJustSpace :: Parser ()
@@ -773,31 +813,35 @@ data CoddCommentParseResult a = CoddCommentWithGibberish !Text | CoddCommentSucc
 -- of malformed codd options!
 coddCommentParser :: Parser (CoddCommentParseResult [SectionOption])
 coddCommentParser = do
-  void $ string "--"
-  skipJustSpace
-  void $ string "codd:"
-  skipJustSpace
-  parseOptions <|> CoddCommentWithGibberish . Text.stripEnd <$> Parsec.takeText
- where
-  parseOptions = do
-    opts <- optionParser `sepBy1` (skipJustSpace >> char ',' >> skipJustSpace)
-    endOfLine
-    pure $ CoddCommentSuccess opts
+    void $ string "--"
+    skipJustSpace
+    void $ string "codd:"
+    skipJustSpace
+    parseOptions
+        <|> CoddCommentWithGibberish
+        .   Text.stripEnd
+        <$> Parsec.takeText
+  where
+    parseOptions = do
+        opts <-
+            optionParser `sepBy1` (skipJustSpace >> char ',' >> skipJustSpace)
+        endOfLine
+        pure $ CoddCommentSuccess opts
 
 -- | Parses a "-- codd-connection: some-connection-string" line. Consumes all available input
 -- in case of a malformed connection string.
 coddConnStringCommentParser :: Parser (CoddCommentParseResult ConnectInfo)
 coddConnStringCommentParser = do
-  void $ string "--"
-  skipJustSpace
-  void $ string "codd-connection:"
-  skipJustSpace
-  parseConn <|> CoddCommentWithGibberish . Text.stripEnd <$> Parsec.takeText
- where
-  parseConn = do
-    connInfo <- connStringParser
-    endOfLine
-    pure $ CoddCommentSuccess connInfo
+    void $ string "--"
+    skipJustSpace
+    void $ string "codd-connection:"
+    skipJustSpace
+    parseConn <|> CoddCommentWithGibberish . Text.stripEnd <$> Parsec.takeText
+  where
+    parseConn = do
+        connInfo <- connStringParser
+        endOfLine
+        pure $ CoddCommentSuccess connInfo
 
 -- | Parses a "-- codd-env-vars: VAR1, VAR2, ..." line. Consumes all available input
 -- in case of malformed options.
@@ -805,21 +849,29 @@ coddConnStringCommentParser = do
 -- even a bit more lax than the proposed one. It is [a-zA-Z_0-9]+
 coddEnvVarsCommentParser :: Parser (CoddCommentParseResult [Text])
 coddEnvVarsCommentParser = do
-  void $ string "--"
-  skipJustSpace
-  void $ string "codd-env-vars:"
-  skipJustSpace
-  parseVarNames <|> CoddCommentWithGibberish . Text.stripEnd <$> Parsec.takeText
- where
-  parseVarNames = do
-    vars <-
-      singleVarNameParser `sepBy1` (skipJustSpace >> char ',' >> skipJustSpace)
-    endOfLine
-    pure $ CoddCommentSuccess vars
-  singleVarNameParser = Parsec.takeWhile1
-    (\c ->
-      Char.isAsciiLower c || Char.isAsciiUpper c || c == '_' || Char.isDigit c
-    )
+    void $ string "--"
+    skipJustSpace
+    void $ string "codd-env-vars:"
+    skipJustSpace
+    parseVarNames
+        <|> CoddCommentWithGibberish
+        .   Text.stripEnd
+        <$> Parsec.takeText
+  where
+    parseVarNames = do
+        vars <-
+            singleVarNameParser
+                `sepBy1` (skipJustSpace >> char ',' >> skipJustSpace)
+        endOfLine
+        pure $ CoddCommentSuccess vars
+    singleVarNameParser = Parsec.takeWhile1
+        (\c ->
+            Char.isAsciiLower c
+                || Char.isAsciiUpper c
+                || c
+                == '_'
+                || Char.isDigit c
+        )
 
 isWhiteSpacePiece :: SqlPiece -> Bool
 isWhiteSpacePiece (WhiteSpacePiece _) = True
@@ -839,9 +891,9 @@ isTransactionEndingPiece _                       = False
 -- extracts from them custom options and a custom connection string when
 -- they exist, or returns a good error message otherwise.
 parseAndClassifyMigration
-  :: (MonadThrow m, MigrationStream m s, EnvVars m)
-  => s
-  -> m (Either String ([SectionOption], Maybe ConnectInfo, ParsedSql m))
+    :: (MonadThrow m, MigrationStream m s, EnvVars m)
+    => s
+    -> m (Either String ([SectionOption], Maybe ConnectInfo, ParsedSql m))
 parseAndClassifyMigration sqlStream = do
   -- There is no easy way to avoid parsing at least up until and including
   -- the first sql statement.
@@ -849,114 +901,123 @@ parseAndClassifyMigration sqlStream = do
   -- too.
   -- We are relying a lot on the parser to do a good job, which it apparently does,
   -- but it may be interesting to think of alternatives here.
-  consumedPieces :> sqlPiecesBodyStream <-
-    Streaming.toList
-    $ Streaming.span (\p -> isCommentPiece p || isWhiteSpacePiece p)
-    $ parseSqlPiecesStreaming
-    $ migStream sqlStream
-  let
-    firstComments      = filter isCommentPiece consumedPieces
-    envVarParseResults = mapMaybe
-      ( (\case
-          Left  _        -> Nothing
-          Right parseRes -> Just parseRes
-        )
-      . (parseOnly (coddEnvVarsCommentParser <* endOfInput) . sqlPieceText)
-      )
-      firstComments
-    malformedEnvVarComment =
-      listToMaybe [ line | CoddCommentWithGibberish line <- envVarParseResults ]
-  case malformedEnvVarComment of
-    Just badLine ->
-      pure
-        $ Left
-        $ "Malformed -- codd-env-vars comment. Make sure there is at least one environment variable, that they are separated by a comma and that they only contain letters, numbers and underscore. Original comment: "
-        <> Text.unpack badLine
-    Nothing -> do
-      envVars <- getEnvVars
-        $ mconcat [ vars | CoddCommentSuccess vars <- envVarParseResults ]
-      let textReplaceEnvVars :: Text -> Text
-          textReplaceEnvVars = Map.foldlWithKey'
-            (\accF var val -> Text.replace ("${" <> var <> "}") val . accF)
-            id
-            envVars
-          allOptSections = mapMaybe
+    consumedPieces :> sqlPiecesBodyStream <-
+        Streaming.toList
+        $ Streaming.span (\p -> isCommentPiece p || isWhiteSpacePiece p)
+        $ parseSqlPiecesStreaming
+        $ migStream sqlStream
+    let firstComments      = filter isCommentPiece consumedPieces
+        envVarParseResults = mapMaybe
             ( (\case
-                Left  _    -> Nothing
-                Right opts -> Just opts
+                  Left  _        -> Nothing
+                  Right parseRes -> Just parseRes
               )
-            . ( parseOnly (coddCommentParser <* endOfInput)
-              . textReplaceEnvVars
+            . ( parseOnly (coddEnvVarsCommentParser <* endOfInput)
               . sqlPieceText
               )
             )
             firstComments
-          customConnString = mapMaybe
-            ( (\case
-                Left  _        -> Nothing
-                Right connInfo -> Just connInfo
-              )
-            . ( parseOnly (coddConnStringCommentParser <* endOfInput)
-              . textReplaceEnvVars
-              . sqlPieceText
-              )
-            )
-            firstComments
-          headMay []      = Nothing
-          headMay (x : _) = Just x
-
-      -- Urgh.. is there no better way of pattern matching the stuff below?
-      eExtr <- case (allOptSections, customConnString) of
-        (_ : _ : _, _) ->
-          pure
-            $ Left
-                "There must be at most one '-- codd:' comment in the first lines of a migration"
-        (_, _ : _ : _) ->
-          pure
-            $ Left
-                "There must be at most one '-- codd-connection:' comment in the first lines of a migration"
-        _ -> case (headMay allOptSections, headMay customConnString) of
-          (Just (CoddCommentWithGibberish badOptions), _) ->
+        malformedEnvVarComment = listToMaybe
+            [ line | CoddCommentWithGibberish line <- envVarParseResults ]
+    case malformedEnvVarComment of
+        Just badLine ->
             pure
-              $  Left
-              $  "The options '"
-              <> Text.unpack badOptions
-              <> "' are invalid. Valid options are either 'in-txn' or 'no-txn'"
-          (_, Just (CoddCommentWithGibberish _badConn)) ->
-            pure
-              $ Left
-                  "Connection string is not a valid libpq connection string. A valid libpq connection string is either in the format 'postgres://username[:password]@host:port/database_name', with URI-encoded (percent-encoded) components except for the host and bracket-surround IPv6 addresses, or in the keyword value pairs format, e.g. 'dbname=database_name host=localhost user=postgres' with escaping for spaces, quotes or empty values. More info at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"
-          (Just (CoddCommentSuccess opts), Just (CoddCommentSuccess conn)) ->
-            pure $ Right (opts, Just conn)
-          (Just (CoddCommentSuccess opts), Nothing) ->
-            pure $ Right (opts, Nothing)
-          (Nothing, Just (CoddCommentSuccess conn)) ->
-            pure $ Right ([], Just conn)
-          (Nothing, Nothing) -> pure $ Right ([], Nothing)
+                $ Left
+                $ "Malformed -- codd-env-vars comment. Make sure there is at least one environment variable, that they are separated by a comma and that they only contain letters, numbers and underscore. Original comment: "
+                <> Text.unpack badLine
+        Nothing -> do
+            envVars <-
+                getEnvVars $ mconcat
+                    [ vars | CoddCommentSuccess vars <- envVarParseResults ]
+            let textReplaceEnvVars :: Text -> Text
+                textReplaceEnvVars = Map.foldlWithKey'
+                    (\accF var val ->
+                        Text.replace ("${" <> var <> "}") val . accF
+                    )
+                    id
+                    envVars
+                allOptSections = mapMaybe
+                    ( (\case
+                          Left  _    -> Nothing
+                          Right opts -> Just opts
+                      )
+                    . ( parseOnly (coddCommentParser <* endOfInput)
+                      . textReplaceEnvVars
+                      . sqlPieceText
+                      )
+                    )
+                    firstComments
+                customConnString = mapMaybe
+                    ( (\case
+                          Left  _        -> Nothing
+                          Right connInfo -> Just connInfo
+                      )
+                    . ( parseOnly (coddConnStringCommentParser <* endOfInput)
+                      . textReplaceEnvVars
+                      . sqlPieceText
+                      )
+                    )
+                    firstComments
+                headMay []      = Nothing
+                headMay (x : _) = Just x
 
-      case eExtr of
-        Left err -> pure $ Left err
-        Right (opts, customConnStr)
-          |
-          -- Detect "-- codd: no-parse"
-            OptNoParse True `elem` opts -> do
-            -- Remember: the original Stream (Of Text) has already been advanced
-            -- beyond its first SQL statement, but **only** if this is an IO-based
-            -- Stream. If this is a pure Stream it will start from the beginning when
-            -- consumed. That is why we prefer to use a special action to retrieve
-            -- the full migration's contents.
-            fullMigContents <- readFullContents sqlStream
-            pure $ Right (opts, customConnStr, UnparsedSql fullMigContents)
-          | otherwise -> pure $ Right
-            ( opts
-            , customConnStr
-            -- Prepend consumedPieces to preserve the property that SqlMigration objects
-            -- will hold the full original SQL.
-            , WellParsedSql
-            $  Streaming.map (mapSqlPiece textReplaceEnvVars)
-            $  Streaming.each consumedPieces
-            <> sqlPiecesBodyStream
-            )
+            -- Urgh.. is there no better way of pattern matching the stuff below?
+            eExtr <- case (allOptSections, customConnString) of
+                (_ : _ : _, _) ->
+                    pure
+                        $ Left
+                              "There must be at most one '-- codd:' comment in the first lines of a migration"
+                (_, _ : _ : _) ->
+                    pure
+                        $ Left
+                              "There must be at most one '-- codd-connection:' comment in the first lines of a migration"
+                _ -> case (headMay allOptSections, headMay customConnString) of
+                    (Just (CoddCommentWithGibberish badOptions), _) ->
+                        pure
+                            $  Left
+                            $  "The options '"
+                            <> Text.unpack badOptions
+                            <> "' are invalid. Valid options are either 'in-txn' or 'no-txn'"
+                    (_, Just (CoddCommentWithGibberish _badConn)) ->
+                        pure
+                            $ Left
+                                  "Connection string is not a valid libpq connection string. A valid libpq connection string is either in the format 'postgres://username[:password]@host:port/database_name', with URI-encoded (percent-encoded) components except for the host and bracket-surround IPv6 addresses, or in the keyword value pairs format, e.g. 'dbname=database_name host=localhost user=postgres' with escaping for spaces, quotes or empty values. More info at https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING"
+                    (Just (CoddCommentSuccess opts), Just (CoddCommentSuccess conn))
+                        -> pure $ Right (opts, Just conn)
+                    (Just (CoddCommentSuccess opts), Nothing) ->
+                        pure $ Right (opts, Nothing)
+                    (Nothing, Just (CoddCommentSuccess conn)) ->
+                        pure $ Right ([], Just conn)
+                    (Nothing, Nothing) -> pure $ Right ([], Nothing)
+
+            case eExtr of
+                Left err -> pure $ Left err
+                Right (opts, customConnStr)
+                    |
+                  -- Detect "-- codd: no-parse"
+                      OptNoParse True `elem` opts -> do
+                    -- Remember: the original Stream (Of Text) has already been advanced
+                    -- beyond its first SQL statement, but **only** if this is an IO-based
+                    -- Stream. If this is a pure Stream it will start from the beginning when
+                    -- consumed. That is why we prefer to use a special action to retrieve
+                    -- the full migration's contents.
+                        fullMigContents <- readFullContents sqlStream
+                        pure
+                            $ Right
+                                  ( opts
+                                  , customConnStr
+                                  , UnparsedSql fullMigContents
+                                  )
+                    | otherwise -> pure $ Right
+                        ( opts
+                        , customConnStr
+                    -- Prepend consumedPieces to preserve the property that SqlMigration objects
+                    -- will hold the full original SQL.
+                        , WellParsedSql
+                        $  Streaming.map (mapSqlPiece textReplaceEnvVars)
+                        $  Streaming.each consumedPieces
+                        <> sqlPiecesBodyStream
+                        )
 
 
 
@@ -965,91 +1026,95 @@ piecesToText = foldr ((<>) . sqlPieceText) ""
 
 {-# INLINE parseSqlMigration #-} -- See Note [Inlining and specialization]
 parseSqlMigration
-  :: forall m s
-   . (MonadThrow m, MigrationStream m s, EnvVars m)
-  => String
-  -> s
-  -> m (Either String (SqlMigration m))
+    :: forall m s
+     . (MonadThrow m, MigrationStream m s, EnvVars m)
+    => String
+    -> s
+    -> m (Either String (SqlMigration m))
 parseSqlMigration name s = (toMig =<<) <$> parseAndClassifyMigration s
- where
-  dupOpts opts = length (nub opts) < length opts
-  checkOpts :: [SectionOption] -> Maybe String
-  checkOpts opts
-    | inTxn opts && noTxn opts = Just
-      "Choose either in-txn, no-txn or leave blank for the default of in-txn"
-    | dupOpts opts = Just "Some options are duplicated"
-    | otherwise = Nothing
-  inTxn opts = OptInTxn False `notElem` opts || OptInTxn True `elem` opts
-  noTxn opts = OptInTxn False `elem` opts
+  where
+    dupOpts opts = length (nub opts) < length opts
+    checkOpts :: [SectionOption] -> Maybe String
+    checkOpts opts
+        | inTxn opts && noTxn opts
+        = Just
+            "Choose either in-txn, no-txn or leave blank for the default of in-txn"
+        | dupOpts opts
+        = Just "Some options are duplicated"
+        | otherwise
+        = Nothing
+    inTxn opts = OptInTxn False `notElem` opts || OptInTxn True `elem` opts
+    noTxn opts = OptInTxn False `elem` opts
 
-  mkMig :: ([SectionOption], Maybe ConnectInfo, ParsedSql m) -> SqlMigration m
-  mkMig (opts, customConnString, sql) = SqlMigration
-    { migrationName           = name
-    , migrationSql            = sql
-    , migrationInTxn          = inTxn opts
-    , migrationCustomConnInfo = customConnString
-    }
+    mkMig
+        :: ([SectionOption], Maybe ConnectInfo, ParsedSql m) -> SqlMigration m
+    mkMig (opts, customConnString, sql) = SqlMigration
+        { migrationName           = name
+        , migrationSql            = sql
+        , migrationInTxn          = inTxn opts
+        , migrationCustomConnInfo = customConnString
+        }
 
-  toMig
-    :: ([SectionOption], Maybe ConnectInfo, ParsedSql m)
-    -> Either String (SqlMigration m)
-  toMig x@(ops, _, _) = case checkOpts ops of
-    Just err -> Left err
-    _        -> Right $ mkMig x
+    toMig
+        :: ([SectionOption], Maybe ConnectInfo, ParsedSql m)
+        -> Either String (SqlMigration m)
+    toMig x@(ops, _, _) = case checkOpts ops of
+        Just err -> Left err
+        _        -> Right $ mkMig x
 
 
 parseAddedSqlMigration
-  :: (MonadThrow m, MigrationStream m s, EnvVars m)
-  => String
-  -> s
-  -> m (Either String (AddedSqlMigration m))
+    :: (MonadThrow m, MigrationStream m s, EnvVars m)
+    => String
+    -> s
+    -> m (Either String (AddedSqlMigration m))
 parseAddedSqlMigration name s = do
-  sqlMig <- parseSqlMigration name s
-  pure $ AddedSqlMigration <$> sqlMig <*> parseMigrationTimestamp name
+    sqlMig <- parseSqlMigration name s
+    pure $ AddedSqlMigration <$> sqlMig <*> parseMigrationTimestamp name
 
 -- | Converts an arbitrary UTCTime (usually the system's clock when adding a migration) to a Postgres timestamptz
 -- in by rounding it to the nearest second to ensure Haskell and Postgres times both behave well. Returns both the rounded UTCTime
 -- and the Postgres timestamp.
 toMigrationTimestamp :: UTCTime -> (UTCTime, DB.UTCTimestamp)
 toMigrationTimestamp (UTCTime day diffTime) =
-  let t = UTCTime day (fromInteger $ round diffTime) in (t, DB.Finite t)
+    let t = UTCTime day (fromInteger $ round diffTime) in (t, DB.Finite t)
 
 -- | Parses the UTC timestamp from a migration's name.
 parseMigrationTimestamp :: String -> Either String DB.UTCTimestamp
 parseMigrationTimestamp name = parseOnly
-  (migTimestampParser <|> fail
-    ("Could not find migration timestamp from its name: '" <> name <> "'")
-  )
-  (Text.pack name)
- where
-  dash               = void $ char '-'
-  migTimestampParser = do
-    yyyy <- Parsec.decimal
-    dash
-    monthMm <- Parsec.decimal
-    dash
-    dd <- Parsec.decimal
-    dash
-    hh <- Parsec.decimal
-    guard $ hh >= 0 && hh <= 23
-    dash
-    minuteMm <- Parsec.decimal
-    guard $ minuteMm >= 0 && minuteMm < 60
-    dash
-    ss <- Parsec.decimal
-    guard $ ss >= 0 && ss < 60
-    case fromGregorianValid yyyy monthMm dd of
-      Nothing -> fail "Invalid date"
-      Just day ->
-        pure
-          $ DB.Finite
-          $ UTCTime day
-          $ secondsToDiffTime
-          $ hh
-          * 3600
-          + minuteMm
-          * 60
-          + ss
+    (migTimestampParser <|> fail
+        ("Could not find migration timestamp from its name: '" <> name <> "'")
+    )
+    (Text.pack name)
+  where
+    dash               = void $ char '-'
+    migTimestampParser = do
+        yyyy <- Parsec.decimal
+        dash
+        monthMm <- Parsec.decimal
+        dash
+        dd <- Parsec.decimal
+        dash
+        hh <- Parsec.decimal
+        guard $ hh >= 0 && hh <= 23
+        dash
+        minuteMm <- Parsec.decimal
+        guard $ minuteMm >= 0 && minuteMm < 60
+        dash
+        ss <- Parsec.decimal
+        guard $ ss >= 0 && ss < 60
+        case fromGregorianValid yyyy monthMm dd of
+            Nothing -> fail "Invalid date"
+            Just day ->
+                pure
+                    $ DB.Finite
+                    $ UTCTime day
+                    $ secondsToDiffTime
+                    $ hh
+                    * 3600
+                    + minuteMm
+                    * 60
+                    + ss
 
 
 -- Note [Inlining and specialization]

--- a/src/Codd/Parsing.hs
+++ b/src/Codd/Parsing.hs
@@ -202,7 +202,7 @@ instance EnvVars IO where
 instance (MonadTrans t, Monad m, EnvVars m) => EnvVars (t m) where
   getEnvVars = lift . getEnvVars
 
-{-# INLINE parseSqlPiecesStreaming #-} -- See Note [Inlining and specialization]
+-- {-# INLINE parseSqlPiecesStreaming #-} -- See Note [Inlining and specialization]
 -- | This should be a rough equivalent to `many parseSqlPiece` for Streams.
 parseSqlPiecesStreaming
   :: forall m
@@ -800,7 +800,7 @@ isTransactionEndingPiece (RollbackTransaction _) = True
 isTransactionEndingPiece (CommitTransaction   _) = True
 isTransactionEndingPiece _                       = False
 
-{-# INLINE parseAndClassifyMigration #-} -- See Note [Inlining and specialization]
+-- {-# INLINE parseAndClassifyMigration #-} -- See Note [Inlining and specialization]
 -- | Parses only comments and white-space that precede the first SQL statement and
 -- extracts from them custom options and a custom connection string when
 -- they exist, or returns a good error message otherwise.
@@ -929,7 +929,7 @@ parseAndClassifyMigration sqlStream = do
 piecesToText :: Foldable t => t SqlPiece -> Text
 piecesToText = foldr ((<>) . sqlPieceText) ""
 
-{-# INLINE parseSqlMigration #-} -- See Note [Inlining and specialization]
+-- {-# INLINE parseSqlMigration #-} -- See Note [Inlining and specialization]
 parseSqlMigration
   :: forall m s
    . (MonadThrow m, MigrationStream m s, EnvVars m)

--- a/src/Codd/Parsing.hs
+++ b/src/Codd/Parsing.hs
@@ -202,7 +202,7 @@ instance EnvVars IO where
 instance (MonadTrans t, Monad m, EnvVars m) => EnvVars (t m) where
   getEnvVars = lift . getEnvVars
 
--- {-# INLINE parseSqlPiecesStreaming #-} -- See Note [Inlining and specialization]
+{-# INLINE parseSqlPiecesStreaming #-} -- See Note [Inlining and specialization]
 -- | This should be a rough equivalent to `many parseSqlPiece` for Streams.
 parseSqlPiecesStreaming
   :: forall m
@@ -800,7 +800,7 @@ isTransactionEndingPiece (RollbackTransaction _) = True
 isTransactionEndingPiece (CommitTransaction   _) = True
 isTransactionEndingPiece _                       = False
 
--- {-# INLINE parseAndClassifyMigration #-} -- See Note [Inlining and specialization]
+{-# INLINE parseAndClassifyMigration #-} -- See Note [Inlining and specialization]
 -- | Parses only comments and white-space that precede the first SQL statement and
 -- extracts from them custom options and a custom connection string when
 -- they exist, or returns a good error message otherwise.
@@ -929,7 +929,7 @@ parseAndClassifyMigration sqlStream = do
 piecesToText :: Foldable t => t SqlPiece -> Text
 piecesToText = foldr ((<>) . sqlPieceText) ""
 
--- {-# INLINE parseSqlMigration #-} -- See Note [Inlining and specialization]
+{-# INLINE parseSqlMigration #-} -- See Note [Inlining and specialization]
 parseSqlMigration
   :: forall m s
    . (MonadThrow m, MigrationStream m s, EnvVars m)

--- a/stack-aeson-2.yaml
+++ b/stack-aeson-2.yaml
@@ -8,6 +8,13 @@ extra-deps:
     commit: fd017a6ee307730f6621ff080bbbf38b0b92d5b7
     # nix-sha256: sha256-3Z9wFjkfSkWq76hiZVVMfZDwPxKNp9mhPgCg0cjC3eI=
 
+  # This version contains more useful GC measures
+  - git: https://github.com/haskell/criterion.git
+    commit: 4d6bd209bc72172c540610182f3f01b688e62e55
+    subdirs:
+      - criterion-measurement
+    # nix-sha256: sha256-I+3skzH526m+44VMyEligLA1G+90ZxDJ+FNhRCJSau4=
+
 flags:
   hashable:
     random-initial-seed: true

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -72,21 +72,21 @@ import           UnliftIO                       ( MonadIO
 import           UnliftIO.Resource              ( runResourceT )
 
 data RandomSql m = RandomSql
-  { unRandomSql  :: PureStream m
-  , fullContents :: Text
-  }
+    { unRandomSql  :: PureStream m
+    , fullContents :: Text
+    }
 instance Show (RandomSql m) where
-  show RandomSql { fullContents } = show fullContents
+    show RandomSql { fullContents } = show fullContents
 
 -- | Syntactically valid SQL must contain at least one statement!
 data SyntacticallyValidRandomSql m = SyntacticallyValidRandomSql
-  { unSyntRandomSql :: PureStream m
-  , fullContents    :: Text
-  }
+    { unSyntRandomSql :: PureStream m
+    , fullContents    :: Text
+    }
 instance Show (SyntacticallyValidRandomSql m) where
-  show SyntacticallyValidRandomSql { fullContents } = show fullContents
+    show SyntacticallyValidRandomSql { fullContents } = show fullContents
 
--- | This is a list because it can be a sequence of `CopyFromStdinStatement`+`CopyFromStdinRow`+`CopyFromStdinEnd`.
+-- | This is a list because it can be a sequence of `CopyFromStdinStatement`+`CopyFromStdinRows`+`CopyFromStdinEnd`.
 -- For all other cases it shall be a single statement.
 genSingleSqlStatement :: Gen [SqlPiece]
 genSingleSqlStatement = elements validSqlStatements
@@ -95,213 +95,217 @@ genSingleSqlStatement = elements validSqlStatements
 -- The inner lists contain statements that _must_ be put consecutively.
 validSqlStatements :: [[SqlPiece]]
 validSqlStatements =
-  map
-      (: [])
-      [ OtherSqlPiece "SELECT 'so\\'m -- not a comment' FROM ahahaha;"
-      , OtherSqlPiece
-      $  "DO"
-      <> "\n$do$"
-      <> "\nBEGIN"
-      <> "\n   IF NOT EXISTS ("
-      <> "\n      SELECT FROM pg_catalog.pg_roles WHERE rolname = 'codd-user') THEN"
-      <> "\n"
-      <> "\n      CREATE USER \"codd-user\";"
-      <> "\n   END IF;"
-      <> "\nEND"
-      <> "\n$do$;"
-      , OtherSqlPiece "CREATE TABLE \"escaped--table /* nasty */\";"
-      , OtherSqlPiece "CREATE TABLE any_table();"
-      , OtherSqlPiece
-      $  "CREATE FUNCTION sales_tax(subtotal real) RETURNS real AS $$"
-      <> "\nBEGIN"
-      <> "\n    RETURN subtotal * 0.06;"
-      <> "\nEND;"
-      <> "\n$$ LANGUAGE plpgsql;"
-      , OtherSqlPiece
-      $  "CREATE FUNCTION instr(varchar, integer) RETURNS integer AS $$"
-      <> "\nDECLARE"
-      <> "\n    v_string ALIAS FOR $1;"
-      <> "\n    index ALIAS FOR $2;"
-      <> "\nBEGIN"
-      <> "\n    -- some computations using v_string and index here"
-      <> "\nEND;"
-      <> "\n$$ LANGUAGE plpgsql;"
-      , OtherSqlPiece
-        "select U&'d\\0061t\\+000061', U&'\\0441\\043B\\043E\\043D', U&'d!0061t!+000061' UESCAPE '!', X'1FF', B'1001';"
-      , OtherSqlPiece "SELECT 'some''quoted ''string';"
-      , OtherSqlPiece "SELECT \"some\"\"quoted identifier\";"
-      , OtherSqlPiece "SELECT 'double quotes \" inside single quotes \" - 2';"
-      , OtherSqlPiece "SELECT \"single quotes ' inside double quotes ' - 2\";"
-      , OtherSqlPiece
-      $  "$function$"
-      <> "\nBEGIN"
-      <> "\n    RETURN ($1 ~ $q$[\t\r\n\v\\]$q$);"
-      <> "\nEND;"
-      <> "\n$function$;"
-      , OtherSqlPiece "SELECT COALESCE(4, 1 - 2) - 3 + 4 - 5;"
-      , OtherSqlPiece "SELECT (1 - 4) / 5 * 3 / 9.1;"
-      , BeginTransaction "begin;"
-      , BeginTransaction "BEGiN/*a*/;"
-      , BeginTransaction "BEgIN   ;"
-      , RollbackTransaction "ROllBaCk;"
-      , RollbackTransaction "ROllBaCk/*a*/;"
-      , RollbackTransaction "ROllBaCk   ;"
-      , CommitTransaction "COmmIT;"
-      , CommitTransaction "COMMIT/*a*/;"
-      , CommitTransaction "cOMMIT   ;"
+    map
+            (: [])
+            [ OtherSqlPiece "SELECT 'so\\'m -- not a comment' FROM ahahaha;"
+            , OtherSqlPiece
+            $  "DO"
+            <> "\n$do$"
+            <> "\nBEGIN"
+            <> "\n   IF NOT EXISTS ("
+            <> "\n      SELECT FROM pg_catalog.pg_roles WHERE rolname = 'codd-user') THEN"
+            <> "\n"
+            <> "\n      CREATE USER \"codd-user\";"
+            <> "\n   END IF;"
+            <> "\nEND"
+            <> "\n$do$;"
+            , OtherSqlPiece "CREATE TABLE \"escaped--table /* nasty */\";"
+            , OtherSqlPiece "CREATE TABLE any_table();"
+            , OtherSqlPiece
+            $  "CREATE FUNCTION sales_tax(subtotal real) RETURNS real AS $$"
+            <> "\nBEGIN"
+            <> "\n    RETURN subtotal * 0.06;"
+            <> "\nEND;"
+            <> "\n$$ LANGUAGE plpgsql;"
+            , OtherSqlPiece
+            $  "CREATE FUNCTION instr(varchar, integer) RETURNS integer AS $$"
+            <> "\nDECLARE"
+            <> "\n    v_string ALIAS FOR $1;"
+            <> "\n    index ALIAS FOR $2;"
+            <> "\nBEGIN"
+            <> "\n    -- some computations using v_string and index here"
+            <> "\nEND;"
+            <> "\n$$ LANGUAGE plpgsql;"
+            , OtherSqlPiece
+                "select U&'d\\0061t\\+000061', U&'\\0441\\043B\\043E\\043D', U&'d!0061t!+000061' UESCAPE '!', X'1FF', B'1001';"
+            , OtherSqlPiece "SELECT 'some''quoted ''string';"
+            , OtherSqlPiece "SELECT \"some\"\"quoted identifier\";"
+            , OtherSqlPiece
+                "SELECT 'double quotes \" inside single quotes \" - 2';"
+            , OtherSqlPiece
+                "SELECT \"single quotes ' inside double quotes ' - 2\";"
+            , OtherSqlPiece
+            $  "$function$"
+            <> "\nBEGIN"
+            <> "\n    RETURN ($1 ~ $q$[\t\r\n\v\\]$q$);"
+            <> "\nEND;"
+            <> "\n$function$;"
+            , OtherSqlPiece "SELECT COALESCE(4, 1 - 2) - 3 + 4 - 5;"
+            , OtherSqlPiece "SELECT (1 - 4) / 5 * 3 / 9.1;"
+            , BeginTransaction "begin;"
+            , BeginTransaction "BEGiN/*a*/;"
+            , BeginTransaction "BEgIN   ;"
+            , RollbackTransaction "ROllBaCk;"
+            , RollbackTransaction "ROllBaCk/*a*/;"
+            , RollbackTransaction "ROllBaCk   ;"
+            , CommitTransaction "COmmIT;"
+            , CommitTransaction "COMMIT/*a*/;"
+            , CommitTransaction "cOMMIT   ;"
     -- TODO: Nested C-Style comments (https://www.postgresql.org/docs/9.2/sql-syntax-lexical.html)
     -- , "/* multiline comment"
     --   <> "\n  * with nesting: /* nested block comment */"
     --   <> "\n  */ SELECT 1;"
-      ]
-    ++ [ [ CopyFromStdinStatement
-           "COPY employee FROM STDIN WITH (FORMAT CSV);\n"
-         , CopyFromStdinRow "5,Dracula,master\n"
-         , CopyFromStdinRow "6,The Grinch,master\n"
-         , CopyFromStdinEnd "\\.\n"
-         ]
-       , [ CopyFromStdinStatement
-           "COPY employee FROM STDIN WITH (FORMAT CSV);\n"
+            ]
+        ++ [ [ CopyFromStdinStatement
+                 "COPY employee FROM STDIN WITH (FORMAT CSV);\n"
+             , CopyFromStdinRows "5,Dracula,master\n"
+             , CopyFromStdinRows "6,The Grinch,master\n"
+             , CopyFromStdinEnd "\\.\n"
+             ]
+           , [ CopyFromStdinStatement
+                 "COPY employee FROM STDIN WITH (FORMAT CSV);\n"
     -- COPY without any rows is syntactically valid
-         , CopyFromStdinEnd "\\.\n"
-         ]
-       , [ CopyFromStdinStatement
-           "copy \"schema\".employee FROM stdin WITH (FORMAT CSV);\n"
-         , CopyFromStdinRow "DATA\n"
-         , CopyFromStdinEnd "\\.\n"
-         ]
-       , [
+             , CopyFromStdinEnd "\\.\n"
+             ]
+           , [ CopyFromStdinStatement
+                 "copy \"schema\".employee FROM stdin WITH (FORMAT CSV);\n"
+             , CopyFromStdinRows "DATA\n"
+             , CopyFromStdinEnd "\\.\n"
+             ]
+           , [
      -- Fully qualified identifiers part 1 + table without columns, but with one row (this is possible!)
-           CopyFromStdinStatement
-           "CoPy \"some-database\"   .  \"schema\"  .  employee from stdin with (FORMAT CSV);\n"
-         , CopyFromStdinRow "\n"
-         , CopyFromStdinEnd "\\.\n"
-         ]
-       , [
+               CopyFromStdinStatement
+                 "CoPy \"some-database\"   .  \"schema\"  .  employee from stdin with (FORMAT CSV);\n"
+             , CopyFromStdinRows "\n"
+             , CopyFromStdinEnd "\\.\n"
+             ]
+           , [
     -- Fully qualified identifiers part 2 + specifying columns
-           CopyFromStdinStatement
-           "CoPy \"employee\"   (col1,\"col2\"   ,   col4  ) from stdin with (FORMAT CSV);\n"
-         , CopyFromStdinRow "Lots of data\n"
-         , CopyFromStdinRow "in\n"
-         , CopyFromStdinRow "each line\n"
-         , CopyFromStdinEnd "\\.\n"
-         ]
-       ,
+               CopyFromStdinStatement
+                 "CoPy \"employee\"   (col1,\"col2\"   ,   col4  ) from stdin with (FORMAT CSV);\n"
+             , CopyFromStdinRows "Lots of data\n"
+             , CopyFromStdinRows "in\n"
+             , CopyFromStdinRows "each line\n"
+             , CopyFromStdinEnd "\\.\n"
+             ]
+           ,
          -- COPY with lots of custom escaping
-         [ CopyFromStdinStatement
-           "COPY whatever FROM STDIN WITH (FORMAT CSV);\n"
-         , CopyFromStdinRow "\\b \\0 \\x1 \\t \\v \\r \\n \\f \\b \n"
-         , CopyFromStdinRow "\b \0 \r \t\n" -- I think these characters are actually invalid in COPY according to postgres.
-         , CopyFromStdinEnd "\\.\n"
-         ]
-       ]
+             [ CopyFromStdinStatement
+                 "COPY whatever FROM STDIN WITH (FORMAT CSV);\n"
+             , CopyFromStdinRows "\\b \\0 \\x1 \\t \\v \\r \\n \\f \\b \n"
+             , CopyFromStdinRows "\b \0 \r \t\n" -- I think these characters are actually invalid in COPY according to postgres.
+             , CopyFromStdinEnd "\\.\n"
+             ]
+           ]
 
 genTextStream :: Monad m => Text -> Gen (PureStream m)
 genTextStream t = do
-  n <- arbitrary
-  pure $ mkRandStream n t
+    n <- arbitrary
+    pure $ mkRandStream n t
 
 mkRandStream :: Monad m => Int -> Text -> PureStream m
 mkRandStream seed t = PureStream $ go (mkStdGen seed) t
- where
-  go g t =
-    let (n, g') = randomR (0, len) g
-        remainder =
-          if t == "" then Streaming.yield "" else go g' (Text.drop n t)
-    in  Streaming.yield (Text.take n t) <> remainder
-    where len = Text.length t
+  where
+    go g t =
+        let
+            (n, g') = randomR (0, len) g
+            remainder =
+                if t == "" then Streaming.yield "" else go g' (Text.drop n t)
+        in
+            Streaming.yield (Text.take n t) <> remainder
+        where len = Text.length t
 
 genSql :: Monad m => Bool -> Gen (PureStream m, Text)
 genSql onlySyntacticallyValid = do
-  t <- frequency
-    [(if onlySyntacticallyValid then 0 else 1, pure ""), (50, randomSqlGen)]
-  (, t) <$> genTextStream t
- where
-  emptyLineGen   = pure "\n"
-  bizarreLineGen = (<> "\n") . Text.pack . getUnicodeString <$> arbitrary
-  lineGen        = frequency
-    [ (if onlySyntacticallyValid then 0 else 1, bizarreLineGen)
-    , (1, emptyLineGen)
-    , (5, piecesToText <$> genSingleSqlStatement)
-    ]
-  -- Note: the likelihood that QuickCheck will randomly generate text that has a line starting with "-- codd:"
-  -- is so low that we can just ignore it
-  dashDashCommentGen =
-    (<> "\n") . ("-- " <>) . Text.replace "\n" "" <$> bizarreLineGen
-  cStyleCommentGen =
-    ("/*" <>) . (<> "*/") . Text.replace "*/" "" <$> bizarreLineGen
-  commentGen       = frequency [(5, dashDashCommentGen), (1, cStyleCommentGen)]
-  lineOrCommentGen = frequency [(5, lineGen), (1, commentGen)]
-  randomSqlGen     = fmap Text.concat $ do
-    l1             <- listOf lineOrCommentGen
-    l2             <- listOf lineOrCommentGen
-    atLeastOneStmt <- piecesToText <$> genSingleSqlStatement
-    let finalList = if onlySyntacticallyValid
-          then l1 ++ (atLeastOneStmt : l2)
-          else l1 ++ l2
+    t <- frequency
+        [(if onlySyntacticallyValid then 0 else 1, pure ""), (50, randomSqlGen)]
+    (, t) <$> genTextStream t
+  where
+    emptyLineGen   = pure "\n"
+    bizarreLineGen = (<> "\n") . Text.pack . getUnicodeString <$> arbitrary
+    lineGen        = frequency
+        [ (if onlySyntacticallyValid then 0 else 1, bizarreLineGen)
+        , (1, emptyLineGen)
+        , (5, piecesToText <$> genSingleSqlStatement)
+        ]
+    -- Note: the likelihood that QuickCheck will randomly generate text that has a line starting with "-- codd:"
+    -- is so low that we can just ignore it
+    dashDashCommentGen =
+        (<> "\n") . ("-- " <>) . Text.replace "\n" "" <$> bizarreLineGen
+    cStyleCommentGen =
+        ("/*" <>) . (<> "*/") . Text.replace "*/" "" <$> bizarreLineGen
+    commentGen = frequency [(5, dashDashCommentGen), (1, cStyleCommentGen)]
+    lineOrCommentGen = frequency [(5, lineGen), (1, commentGen)]
+    randomSqlGen = fmap Text.concat $ do
+        l1             <- listOf lineOrCommentGen
+        l2             <- listOf lineOrCommentGen
+        atLeastOneStmt <- piecesToText <$> genSingleSqlStatement
+        let finalList = if onlySyntacticallyValid
+                then l1 ++ (atLeastOneStmt : l2)
+                else l1 ++ l2
 
-        mapLast :: (a -> a) -> [a] -> [a]
-        mapLast _ []       = []
-        mapLast f [x     ] = [f x]
-        mapLast f (x : xs) = x : mapLast f xs
+            mapLast :: (a -> a) -> [a] -> [a]
+            mapLast _ []       = []
+            mapLast f [x     ] = [f x]
+            mapLast f (x : xs) = x : mapLast f xs
 
-    -- Optionally remove semi-colon from the last command if it ends with one
-    removeLastSemiColon <- arbitrary
-    pure $ if removeLastSemiColon
-      then mapLast (\t -> fromMaybe t (Text.stripSuffix ";" t)) finalList
-      else finalList
+        -- Optionally remove semi-colon from the last command if it ends with one
+        removeLastSemiColon <- arbitrary
+        pure $ if removeLastSemiColon
+            then mapLast (\t -> fromMaybe t (Text.stripSuffix ";" t)) finalList
+            else finalList
 
 instance Monad m => Arbitrary (RandomSql m) where
-  arbitrary = uncurry RandomSql <$> genSql False
+    arbitrary = uncurry RandomSql <$> genSql False
 
 instance Monad m => Arbitrary (SyntacticallyValidRandomSql m) where
-  arbitrary = uncurry SyntacticallyValidRandomSql <$> genSql True
+    arbitrary = uncurry SyntacticallyValidRandomSql <$> genSql True
 
 data CopyBody m = CopyBody
-  { numLines   :: Int
-  , chunkSize  :: Int
-  , terminator :: Text
-  , rows       :: [Text]
-  }
-  deriving stock Show
+    { numLines   :: Int
+    , chunkSize  :: Int
+    , terminator :: Text
+    , rows       :: [Text]
+    }
+    deriving stock Show
 
 instance Arbitrary (CopyBody m) where
-  arbitrary = do
-    numLines   <- chooseInt (0, 99)
-    chunkSize  <- chooseInt (1, 10)
-    terminator <- elements ["\\.", "\\.\n", ""] -- We also accept no terminator (maybe that's overly relaxed compared to psql, but oh well)
-    rows       <- forM [1 .. numLines] $ \_ -> do
-      notEnding       <- elements ["\\", ".", "\\.", ".\\", ""] -- Any characters that look like a terminator and could confuse the parser
-      someCharsBefore <- arbitrary
-      someCharsAfter  <- arbitrary
-      before          <- Text.pack <$> if someCharsBefore
-        then listOf1 (arbitrary @Char `suchThat` (/=) '\n')
-        else pure ""
-      after <- Text.pack <$> if someCharsAfter
-        then listOf1 (arbitrary @Char `suchThat` (/=) '\n')
-        else pure ""
-      let row' = before <> notEnding <> after <> "\n"
-          row  = if row' == "\\.\n" then "x\\.\n" else row'
-      pure row
-    pure $ CopyBody { .. }
+    arbitrary = do
+        numLines   <- chooseInt (0, 99)
+        chunkSize  <- chooseInt (1, 10)
+        terminator <- elements ["\\.", "\\.\n", ""] -- We also accept no terminator (maybe that's overly relaxed compared to psql, but oh well)
+        rows       <- forM [1 .. numLines] $ \_ -> do
+            notEnding       <- elements ["\\", ".", "\\.", ".\\", ""] -- Any characters that look like a terminator and could confuse the parser
+            someCharsBefore <- arbitrary
+            someCharsAfter  <- arbitrary
+            before          <- Text.pack <$> if someCharsBefore
+                then listOf1 (arbitrary @Char `suchThat` (/=) '\n')
+                else pure ""
+            after <- Text.pack <$> if someCharsAfter
+                then listOf1 (arbitrary @Char `suchThat` (/=) '\n')
+                else pure ""
+            let row' = before <> notEnding <> after <> "\n"
+                row  = if row' == "\\.\n" then "x\\.\n" else row'
+            pure row
+        pure $ CopyBody { .. }
 
 shouldHaveWellParsedSql :: MonadIO m => SqlMigration m -> Text -> m ()
 mig `shouldHaveWellParsedSql` sql = case migrationSql mig of
-  UnparsedSql _        -> liftIO $ expectationFailure "Got UnparsedSql"
-  ps@(WellParsedSql _) -> do
-    psql <- parsedSqlText ps
-    liftIO $ psql `shouldBe` sql
+    UnparsedSql _        -> liftIO $ expectationFailure "Got UnparsedSql"
+    ps@(WellParsedSql _) -> do
+        psql <- parsedSqlText ps
+        liftIO $ psql `shouldBe` sql
 
 shouldHaveUnparsedSql :: MonadIO m => SqlMigration m -> Text -> m ()
 shouldHaveUnparsedSql mig expectedSql = case migrationSql mig of
-  WellParsedSql _   -> liftIO $ expectationFailure "Got WellParsedSql instead"
-  UnparsedSql   sql -> liftIO $ sql `shouldBe` expectedSql
+    WellParsedSql _   -> liftIO $ expectationFailure "Got WellParsedSql instead"
+    UnparsedSql   sql -> liftIO $ sql `shouldBe` expectedSql
 
 -- | Same as a monadic `shouldSatisfy` isLeft, but does not require a Show instance.
 shouldReturnLeft :: MonadIO m => m (Either a b) -> m ()
 shouldReturnLeft mv = mv >>= \case
-  Left  _ -> pure ()
-  Right _ -> liftIO $ expectationFailure "Got Right but was expecting Left"
+    Left  _ -> pure ()
+    Right _ -> liftIO $ expectationFailure "Got Right but was expecting Left"
 
 
 {- A quick-n-dirty transformer to serve as a mock of the EnvVars monad -}
@@ -313,281 +317,301 @@ newtype EnvVarsT m a = EnvVarsT { runEnvVarsT :: Map Text Text -> m a }
 instance {-# OVERLAPPING #-} EnvVars (EnvVarsT Identity) where
   -- Important invariant: 
   -- All asked-for environment variables must appear in the result Map.
-  getEnvVars vars = EnvVarsT $ \r -> pure $ foldr
-    (\k res -> let v = Map.findWithDefault "" k r in Map.insert k v res)
-    mempty
-    vars
+    getEnvVars vars = EnvVarsT $ \r -> pure $ foldr
+        (\k res -> let v = Map.findWithDefault "" k r in Map.insert k v res)
+        mempty
+        vars
 
 instance Monad m => MonadThrow (EnvVarsT m) where
-  throwM = error "throwM not implemented"
+    throwM = error "throwM not implemented"
 
 instance Applicative m => Applicative (EnvVarsT m) where
-  pure v = EnvVarsT $ const (pure v)
-  EnvVarsT run1 <*> EnvVarsT run2 = EnvVarsT $ \r -> run1 r <*> run2 r
+    pure v = EnvVarsT $ const (pure v)
+    EnvVarsT run1 <*> EnvVarsT run2 = EnvVarsT $ \r -> run1 r <*> run2 r
 {- ------------------------------------------------------------------- -}
 
 instance Monad m => Monad (EnvVarsT m) where
-  EnvVarsT run1 >>= f = EnvVarsT $ \r -> do
-    v <- run1 r
-    let EnvVarsT run2 = f v
-    run2 r
+    EnvVarsT run1 >>= f = EnvVarsT $ \r -> do
+        v <- run1 r
+        let EnvVarsT run2 = f v
+        run2 r
 
--- | Concatenates text inside consecutive `CopyFromStdinRow` pieces into a single `CopyFromStdinRow`. Keeps other
+-- | Concatenates text inside consecutive `CopyFromStdinRows` pieces into a single `CopyFromStdinRows`. Keeps other
 -- pieces intact.
 groupCopyRows :: [SqlPiece] -> [SqlPiece]
 groupCopyRows = map concatCopy . List.groupBy
-  (\a b -> case (a, b) of
-    (CopyFromStdinRow _, CopyFromStdinRow _) -> True
-    _ -> False
-  )
- where
-  concatCopy :: [SqlPiece] -> SqlPiece
-  concatCopy []       = error "Empty list!"
-  concatCopy [x]      = x
-  concatCopy copyRows = CopyFromStdinRow $ Text.concat $ map
-    (\case
-      CopyFromStdinRow r -> r
-      _                  -> error "Not a Copy row!!"
+    (\a b -> case (a, b) of
+        (CopyFromStdinRows _, CopyFromStdinRows _) -> True
+        _ -> False
     )
-    copyRows
+  where
+    concatCopy :: [SqlPiece] -> SqlPiece
+    concatCopy []       = error "Empty list!"
+    concatCopy [x]      = x
+    concatCopy copyRows = CopyFromStdinRows $ Text.concat $ map
+        (\case
+            CopyFromStdinRows r -> r
+            _                   -> error "Not a Copy row!!"
+        )
+        copyRows
 
 spec :: Spec
 spec = do
-  describe "Parsing tests" $ do
-    context "Multi Query Statement Parser" $ do
-      it "Single command with and without semi-colon"
-        $ property
-        $ \randomSeed -> do
-            blks :: [[SqlPiece]] <- traverse
-              ( (Streaming.toList_ . parseSqlPiecesStreaming)
-              . unPureStream
-              . mkRandStream randomSeed
-              )
-              [ "CREATE TABLE hello;"
-              , "CREATE TABLE hello"
-              , "CREATE TABLE hello; -- Comment"
-              , "CREATE TABLE hello -- Comment"
-              , "CREATE TABLE hello -- Comment\n;"
-              ]
-            blks
-              `shouldBe` [ [OtherSqlPiece "CREATE TABLE hello;"]
-                         , [OtherSqlPiece "CREATE TABLE hello"]
-                         , [ OtherSqlPiece "CREATE TABLE hello;"
-                           , WhiteSpacePiece " "
-                           , CommentPiece "-- Comment"
-                           ]
-                         , [OtherSqlPiece "CREATE TABLE hello -- Comment"]
-                         , [OtherSqlPiece "CREATE TABLE hello -- Comment\n;"]
-                         ]
-      modifyMaxSuccess (const 10000)
-        $ it "Statement separation boundaries are good"
-        $ forAll ((,) <$> listOf1 genSingleSqlStatement <*> arbitrary @Int)
-        $ \(origPieces, randomSeed) -> do
-            parsedPieces <-
-              Streaming.toList_
-              $ parseSqlPiecesStreaming
-              $ unPureStream
-              $ mkRandStream randomSeed
-              $ Text.concat (map piecesToText origPieces)
-            groupCopyRows parsedPieces
-              `shouldBe` groupCopyRows (mconcat origPieces)
-      modifyMaxSuccess (const 10000)
-        $ it
-            "Statements concatenation matches original and statements end with semi-colon"
-        $ do
-            property $ \SyntacticallyValidRandomSql {..} -> do
-              blks <- Streaming.toList_ $ parseSqlPiecesStreaming $ unPureStream
-                unSyntRandomSql
-              let comments = [ t | CommentPiece t <- blks ]
-                  whtspc   = [ t | WhiteSpacePiece t <- blks ]
-              piecesToText blks `shouldBe` fullContents
-              forM_ blks $ \case
-                CommentPiece t ->
-                  t
-                    `shouldSatisfy` (\c ->
-                                      "--"
-                                        `Text.isPrefixOf` c
-                                        ||                "/*"
-                                        `Text.isPrefixOf` c
-                                        &&                "*/"
-                                        `Text.isSuffixOf` c
-                                    )
-                WhiteSpacePiece t ->
-                  t `shouldSatisfy` (\c -> Text.strip c == "")
-                CopyFromStdinEnd ll -> ll `shouldBe` "\\.\n"
-                _                   -> pure ()
+    describe "Parsing tests" $ do
+        context "Multi Query Statement Parser" $ do
+            it "Single command with and without semi-colon"
+                $ property
+                $ \randomSeed -> do
+                      blks :: [[SqlPiece]] <- traverse
+                          ( (Streaming.toList_ . parseSqlPiecesStreaming)
+                          . unPureStream
+                          . mkRandStream randomSeed
+                          )
+                          [ "CREATE TABLE hello;"
+                          , "CREATE TABLE hello"
+                          , "CREATE TABLE hello; -- Comment"
+                          , "CREATE TABLE hello -- Comment"
+                          , "CREATE TABLE hello -- Comment\n;"
+                          ]
+                      blks
+                          `shouldBe` [ [OtherSqlPiece "CREATE TABLE hello;"]
+                                     , [OtherSqlPiece "CREATE TABLE hello"]
+                                     , [ OtherSqlPiece "CREATE TABLE hello;"
+                                       , WhiteSpacePiece " "
+                                       , CommentPiece "-- Comment"
+                                       ]
+                                     , [ OtherSqlPiece
+                                             "CREATE TABLE hello -- Comment"
+                                       ]
+                                     , [ OtherSqlPiece
+                                             "CREATE TABLE hello -- Comment\n;"
+                                       ]
+                                     ]
+            modifyMaxSuccess (const 10000)
+                $ it "Statement separation boundaries are good"
+                $ forAll
+                      ((,) <$> listOf1 genSingleSqlStatement <*> arbitrary @Int)
+                $ \(origPieces, randomSeed) -> do
+                      parsedPieces <-
+                          Streaming.toList_
+                          $ parseSqlPiecesStreaming
+                          $ unPureStream
+                          $ mkRandStream randomSeed
+                          $ Text.concat (map piecesToText origPieces)
+                      groupCopyRows parsedPieces
+                          `shouldBe` groupCopyRows (mconcat origPieces)
+            modifyMaxSuccess (const 10000)
+                $ it
+                      "Statements concatenation matches original and statements end with semi-colon"
+                $ do
+                      property $ \SyntacticallyValidRandomSql {..} -> do
+                          blks <-
+                              Streaming.toList_
+                              $ parseSqlPiecesStreaming
+                              $ unPureStream unSyntRandomSql
+                          let comments = [ t | CommentPiece t <- blks ]
+                              whtspc   = [ t | WhiteSpacePiece t <- blks ]
+                          piecesToText blks `shouldBe` fullContents
+                          forM_ blks $ \case
+                              CommentPiece t ->
+                                  t
+                                      `shouldSatisfy` (\c ->
+                                                          "--"
+                                                              `Text.isPrefixOf` c
+                                                              || "/*"
+                                                              `Text.isPrefixOf` c
+                                                              && "*/"
+                                                              `Text.isSuffixOf` c
+                                                      )
+                              WhiteSpacePiece t ->
+                                  t `shouldSatisfy` (\c -> Text.strip c == "")
+                              CopyFromStdinEnd ll -> ll `shouldBe` "\\.\n"
+                              _                   -> pure ()
 
-      modifyMaxSuccess (const 10000)
-        $ it "Parser of the body of COPY works for odd inputs"
-        $ property
-        $ \CopyBody {..} -> do
-        -- We want to stress-test this parser at its boundaries: lines ending close to chunkSize, terminators in the contents etc.
-            let rowsText = Text.concat rows
-                copyBody = Streaming.each rows <> Streaming.yield terminator
-            parsed <- Streaming.toList_ $ parseSqlPiecesStreaming'
-              (\_parserState -> copyFromStdinAfterStatementParser chunkSize)
-              copyBody
+            modifyMaxSuccess (const 10000)
+                $ it "Parser of the body of COPY works for odd inputs"
+                $ property
+                $ \CopyBody {..} -> do
+              -- We want to stress-test this parser at its boundaries: lines ending close to chunkSize, terminators in the contents etc.
+                      let rowsText = Text.concat rows
+                          copyBody =
+                              Streaming.each rows <> Streaming.yield terminator
+                      parsed <- Streaming.toList_ $ parseSqlPiecesStreaming'
+                          (\_parserState ->
+                              copyFromStdinAfterStatementParser chunkSize
+                          )
+                          copyBody
 
-            groupCopyRows parsed
-              `shouldBe` [ CopyFromStdinRow rowsText | numLines /= 0 ]
-              ++         [ CopyFromStdinEnd terminator | terminator /= "" ]
-            forM_ [ rows | CopyFromStdinRow rows <- parsed ]
-              $ \rows -> rows `shouldSatisfy` ("\n" `Text.isSuffixOf`)
+                      groupCopyRows parsed
+                          `shouldBe` [ CopyFromStdinRows rowsText
+                                     | numLines /= 0
+                                     ]
+                          ++ [ CopyFromStdinEnd terminator | terminator /= "" ]
+                      forM_ [ rows | CopyFromStdinRows rows <- parsed ]
+                          $ \rows ->
+                                rows `shouldSatisfy` ("\n" `Text.isSuffixOf`)
 
 
-    context "Valid SQL Migrations" $ do
-      it "Plain Sql Migration, missing optional options"
-        $ property @(SyntacticallyValidRandomSql IO -> IO ())
-        $ \SyntacticallyValidRandomSql {..} -> do
-            Right parsedMig <- parseSqlMigration "any-name.sql" unSyntRandomSql
-            migrationName parsedMig `shouldBe` "any-name.sql"
-            parsedMig `shouldHaveWellParsedSql` fullContents
-            migrationInTxn parsedMig `shouldBe` True
-            migrationCustomConnInfo parsedMig `shouldBe` Nothing
-      it "Sql Migration options parsed correctly" $ property $ \randomSeed -> do
-        let sql = "-- codd: no-txn\nSOME SQL"
-        Right parsedMig <- parseSqlMigrationIO "any-name.sql"
-          $ mkRandStream randomSeed sql
-        migrationName parsedMig `shouldBe` "any-name.sql"
-        parsedMig `shouldHaveWellParsedSql` sql
-        migrationInTxn parsedMig `shouldBe` False
-        migrationCustomConnInfo parsedMig `shouldBe` Nothing
+        context "Valid SQL Migrations" $ do
+            it "Plain Sql Migration, missing optional options"
+                $ property @(SyntacticallyValidRandomSql IO -> IO ())
+                $ \SyntacticallyValidRandomSql {..} -> do
+                      Right parsedMig <- parseSqlMigration "any-name.sql"
+                                                           unSyntRandomSql
+                      migrationName parsedMig `shouldBe` "any-name.sql"
+                      parsedMig `shouldHaveWellParsedSql` fullContents
+                      migrationInTxn parsedMig `shouldBe` True
+                      migrationCustomConnInfo parsedMig `shouldBe` Nothing
+            it "Sql Migration options parsed correctly"
+                $ property
+                $ \randomSeed -> do
+                      let sql = "-- codd: no-txn\nSOME SQL"
+                      Right parsedMig <-
+                          parseSqlMigrationIO "any-name.sql"
+                              $ mkRandStream randomSeed sql
+                      migrationName parsedMig `shouldBe` "any-name.sql"
+                      parsedMig `shouldHaveWellParsedSql` sql
+                      migrationInTxn parsedMig `shouldBe` False
+                      migrationCustomConnInfo parsedMig `shouldBe` Nothing
 
-      it "Sql Migration connection and custom options"
-        $ property
-        $ \(ConnStringGen connStr connInfo, randomSeed) -> do
-            let
-              sql1 =
-                "\n-- codd: no-txn\n"
-                  <> "\n\n-- codd-connection: "
-                  <> connStr
-                  <> "\n\nSOME SQL"
-              sql2 =
-                "\n\n-- codd-connection: "
-                  <> connStr
-                  <> "\n-- codd: in-txn\n"
-                  <> "SOME SQL"
-            parsedMig1 <- either (error "Oh no") id
-              <$> parseSqlMigrationIO
-                    "any-name.sql"
-                    (mkRandStream randomSeed sql1)
-            migrationName parsedMig1 `shouldBe` "any-name.sql"
-            parsedMig1 `shouldHaveWellParsedSql` sql1
-            migrationInTxn parsedMig1 `shouldBe` False
-            migrationCustomConnInfo parsedMig1 `shouldBe` Just connInfo
+            it "Sql Migration connection and custom options"
+                $ property
+                $ \(ConnStringGen connStr connInfo, randomSeed) -> do
+                      let sql1 =
+                              "\n-- codd: no-txn\n"
+                                  <> "\n\n-- codd-connection: "
+                                  <> connStr
+                                  <> "\n\nSOME SQL"
+                          sql2 =
+                              "\n\n-- codd-connection: "
+                                  <> connStr
+                                  <> "\n-- codd: in-txn\n"
+                                  <> "SOME SQL"
+                      parsedMig1 <-
+                          either (error "Oh no") id
+                              <$> parseSqlMigrationIO
+                                      "any-name.sql"
+                                      (mkRandStream randomSeed sql1)
+                      migrationName parsedMig1 `shouldBe` "any-name.sql"
+                      parsedMig1 `shouldHaveWellParsedSql` sql1
+                      migrationInTxn parsedMig1 `shouldBe` False
+                      migrationCustomConnInfo parsedMig1
+                          `shouldBe` Just connInfo
 
-            parsedMig2 <- either (error "Oh nooo") id
-              <$> parseSqlMigrationIO
-                    "any-name.sql"
-                    (mkRandStream randomSeed sql2)
-            migrationName parsedMig2 `shouldBe` "any-name.sql"
-            parsedMig2 `shouldHaveWellParsedSql` sql2
-            migrationInTxn parsedMig2 `shouldBe` True
-            migrationCustomConnInfo parsedMig2 `shouldBe` Just connInfo
+                      parsedMig2 <-
+                          either (error "Oh nooo") id
+                              <$> parseSqlMigrationIO
+                                      "any-name.sql"
+                                      (mkRandStream randomSeed sql2)
+                      migrationName parsedMig2 `shouldBe` "any-name.sql"
+                      parsedMig2 `shouldHaveWellParsedSql` sql2
+                      migrationInTxn parsedMig2 `shouldBe` True
+                      migrationCustomConnInfo parsedMig2
+                          `shouldBe` Just connInfo
 
-      it "Sql Migration connection option alone"
-        $ property
-        $ \(ConnStringGen connStr connInfo, randomSeed) -> do
-            let
-              sql =
-                "-- random comment\n-- codd-connection: "
-                  <> connStr
-                  <> "\nSOME SQL"
-            mig <- either (error "Oh no") id
-              <$> parseSqlMigrationIO
-                    "any-name.sql"
-                    (mkRandStream randomSeed sql)
-            migrationName mig `shouldBe` "any-name.sql"
-            mig `shouldHaveWellParsedSql` sql
-            migrationInTxn mig `shouldBe` True
-            migrationCustomConnInfo mig `shouldBe` Just connInfo
+            it "Sql Migration connection option alone"
+                $ property
+                $ \(ConnStringGen connStr connInfo, randomSeed) -> do
+                      let
+                          sql =
+                              "-- random comment\n-- codd-connection: "
+                                  <> connStr
+                                  <> "\nSOME SQL"
+                      mig <- either (error "Oh no") id
+                          <$> parseSqlMigrationIO
+                                  "any-name.sql"
+                                  (mkRandStream randomSeed sql)
+                      migrationName mig `shouldBe` "any-name.sql"
+                      mig `shouldHaveWellParsedSql` sql
+                      migrationInTxn mig `shouldBe` True
+                      migrationCustomConnInfo mig `shouldBe` Just connInfo
 
-      it "Sql Migration parsed from disk with full contents"
-        $ runResourceT @IO
-        $ runStdoutLoggingT
-        $ do
-            [BlockOfMigrations { allMigs = asqlmig :| [] }] <-
-              parseMigrationFiles []
-                $ Left ["test/migrations/normal-parse-test/"]
-            rawFileContents <-
-              liftIO
-                $ Text.readFile
-                    "test/migrations/normal-parse-test/2000-01-01-00-00-00-normal-parse-migration.sql"
-            let (AddedSqlMigration mig _) = asqlmig
-            mig `shouldHaveWellParsedSql` rawFileContents
+            it "Sql Migration parsed from disk with full contents"
+                $ runResourceT @IO
+                $ runStdoutLoggingT
+                $ do
+                      [BlockOfMigrations { allMigs = asqlmig :| [] }] <-
+                          parseMigrationFiles []
+                              $ Left ["test/migrations/normal-parse-test/"]
+                      rawFileContents <-
+                          liftIO
+                              $ Text.readFile
+                                    "test/migrations/normal-parse-test/2000-01-01-00-00-00-normal-parse-migration.sql"
+                      let (AddedSqlMigration mig _) = asqlmig
+                      mig `shouldHaveWellParsedSql` rawFileContents
 
-      it "--codd: no-parse returns UnparsedSql"
-        $ property
-        $ \(RandomSql { unRandomSql, fullContents }, randomSeed) -> do
-            let coddOpts = "-- codd: no-parse\n"
-                sql      = coddOpts <> fullContents
+            it "--codd: no-parse returns UnparsedSql"
+                $ property
+                $ \(RandomSql { unRandomSql, fullContents }, randomSeed) -> do
+                      let coddOpts = "-- codd: no-parse\n"
+                          sql      = coddOpts <> fullContents
 
-            mig <- either (error "Oops") id <$> parseSqlMigrationIO
-              "no-parse-migration.sql"
-              (mkRandStream randomSeed coddOpts <> unRandomSql)
-            migrationName mig `shouldBe` "no-parse-migration.sql"
-            mig `shouldHaveUnparsedSql` sql
-            migrationInTxn mig `shouldBe` True
-            migrationCustomConnInfo mig `shouldBe` Nothing
+                      mig <- either (error "Oops") id <$> parseSqlMigrationIO
+                          "no-parse-migration.sql"
+                          (mkRandStream randomSeed coddOpts <> unRandomSql)
+                      migrationName mig `shouldBe` "no-parse-migration.sql"
+                      mig `shouldHaveUnparsedSql` sql
+                      migrationInTxn mig `shouldBe` True
+                      migrationCustomConnInfo mig `shouldBe` Nothing
 
-      it "--codd: no-parse preserves all of migrations file contents"
-        $ runResourceT @IO
-        $ runStdoutLoggingT
-        $ do
-            [BlockOfMigrations { allMigs = asqlmig :| [] }] <-
-              parseMigrationFiles [] $ Left ["test/migrations/no-parse-test/"]
-            rawFileContents <-
-              liftIO
-                $ Text.readFile
-                    "test/migrations/no-parse-test/2000-01-01-00-00-00-no-parse-migration.sql"
-            let (AddedSqlMigration mig _) = asqlmig
-            mig `shouldHaveUnparsedSql` rawFileContents
+            it "--codd: no-parse preserves all of migrations file contents"
+                $ runResourceT @IO
+                $ runStdoutLoggingT
+                $ do
+                      [BlockOfMigrations { allMigs = asqlmig :| [] }] <-
+                          parseMigrationFiles []
+                              $ Left ["test/migrations/no-parse-test/"]
+                      rawFileContents <-
+                          liftIO
+                              $ Text.readFile
+                                    "test/migrations/no-parse-test/2000-01-01-00-00-00-no-parse-migration.sql"
+                      let (AddedSqlMigration mig _) = asqlmig
+                      mig `shouldHaveUnparsedSql` rawFileContents
 
-      it "--codd: no-parse with custom connection-string"
-        $ property
-        $ \randomSeed -> do
-            let
-              sql
-                = "-- codd: no-parse\n\
+            it "--codd: no-parse with custom connection-string"
+                $ property
+                $ \randomSeed -> do
+                      let
+                          sql
+                              = "-- codd: no-parse\n\
             \-- codd-connection: user=codd_admin dbname='codd-experiments' host=127.0.0.1 port=5433\n\
             \-- Anything here!\
             \Some statement; -- Some comment\n\
             \Other statement"
 
-            mig <- either (error "Oops") id
-              <$> parseSqlMigrationIO
-                    "no-parse-migration.sql"
-                    (mkRandStream randomSeed sql)
-            migrationName mig `shouldBe` "no-parse-migration.sql"
-            mig `shouldHaveUnparsedSql` sql
-            migrationInTxn mig `shouldBe` True
-            migrationCustomConnInfo mig `shouldBe` Just DB.ConnectInfo
-              { DB.connectUser     = "codd_admin"
-              , DB.connectHost     = "127.0.0.1"
-              , DB.connectPort     = 5433
-              , DB.connectPassword = ""
-              , DB.connectDatabase = "codd-experiments"
-              }
+                      mig <- either (error "Oops") id
+                          <$> parseSqlMigrationIO
+                                  "no-parse-migration.sql"
+                                  (mkRandStream randomSeed sql)
+                      migrationName mig `shouldBe` "no-parse-migration.sql"
+                      mig `shouldHaveUnparsedSql` sql
+                      migrationInTxn mig `shouldBe` True
+                      migrationCustomConnInfo mig `shouldBe` Just DB.ConnectInfo
+                          { DB.connectUser     = "codd_admin"
+                          , DB.connectHost     = "127.0.0.1"
+                          , DB.connectPort     = 5433
+                          , DB.connectPassword = ""
+                          , DB.connectDatabase = "codd-experiments"
+                          }
 
-      it "-- codd-env-vars templating" $ do
-        let
-          sqlWithVars
-            = "-- codd: no-txn\n\
+            it "-- codd-env-vars templating" $ do
+                let sqlWithVars
+                        = "-- codd: no-txn\n\
                   \-- codd-connection: postgres://${PGSUPERUSER}@${PGHOST}:${PGPORT}/postgres\n\
                   \-- codd-env-vars: PGSUPERUSER ,PGHOST,PGUSER, PGPORT  , UNDEFINED_VAR23, PGDATABASE\n\
                   \CREATE DATABASE ${PGDATABASE};\n\
                   \SELECT \"${PGUSER}\";\n\
                   \SELECT ${NOTAVARIABLE};\n\
                   \SELECT ${UNDEFINED_VAR23}"
-          vars = Map.fromList
-            [ ("PGSUPERUSER", "dbsuperuser")
-            , ("PGHOST"     , "someaddress")
-            , ("PGPORT"     , "5432")
-            , ("PGUSER"     , "codd_user")
-            , ("PGDATABASE" , "codd_db")
-            ]
-          templatedSql
-            = "-- codd: no-txn\n\
+                    vars = Map.fromList
+                        [ ("PGSUPERUSER", "dbsuperuser")
+                        , ("PGHOST"     , "someaddress")
+                        , ("PGPORT"     , "5432")
+                        , ("PGUSER"     , "codd_user")
+                        , ("PGDATABASE" , "codd_db")
+                        ]
+                    templatedSql
+                        = "-- codd: no-txn\n\
                   \-- codd-connection: postgres://dbsuperuser@someaddress:5432/postgres\n\
                   \-- codd-env-vars: PGSUPERUSER ,PGHOST,PGUSER, PGPORT  , UNDEFINED_VAR23, PGDATABASE\n\
                   \CREATE DATABASE codd_db;\n\
@@ -595,150 +619,179 @@ spec = do
                   \SELECT ${NOTAVARIABLE};\n\
                   \SELECT " -- Declared in the header but not defined is replaced by empty
 
-        -- EnvVarsT over Identity is our way to mock environment variables
-        let parsedSql = runIdentity $ flip runEnvVarsT vars $ do
-              res <-
-                parseAndClassifyMigration
-                $ PureStream @(EnvVarsT Identity)
-                $ Streaming.yield sqlWithVars
-              case res of
-                Left  err                   -> error err
-                Right (_, _, UnparsedSql _) -> error "Got UnparsedSql"
-                Right (_, _, WellParsedSql pieces) ->
-                  mconcat . map sqlPieceText <$> Streaming.toList_ pieces
-        parsedSql `shouldBe` templatedSql
+                -- EnvVarsT over Identity is our way to mock environment variables
+                let
+                    parsedSql = runIdentity $ flip runEnvVarsT vars $ do
+                        res <-
+                            parseAndClassifyMigration
+                            $ PureStream @(EnvVarsT Identity)
+                            $ Streaming.yield sqlWithVars
+                        case res of
+                            Left err -> error err
+                            Right (_, _, UnparsedSql _) ->
+                                error "Got UnparsedSql"
+                            Right (_, _, WellParsedSql pieces) ->
+                                mconcat
+                                    .   map sqlPieceText
+                                    <$> Streaming.toList_ pieces
+                parsedSql `shouldBe` templatedSql
 
-    context "Invalid SQL Migrations" $ do
-      modifyMaxSuccess (const 10000)
-        $ it "Sql Migration Parser never blocks for random text"
-        $ do
-            property $ \RandomSql { unRandomSql, fullContents } -> do
-              emig <- parseSqlMigrationIO "any-name.sql" unRandomSql
-              case migrationSql <$> emig of
-                Left  _                      -> error "Should not be Left!"
-                Right (WellParsedSql pieces) -> do
-                  t <- piecesToText <$> Streaming.toList_ pieces
-                  t `shouldBe` fullContents
-                Right (UnparsedSql t) -> t `shouldBe` fullContents
+        context "Invalid SQL Migrations" $ do
+            modifyMaxSuccess (const 10000)
+                $ it "Sql Migration Parser never blocks for random text"
+                $ do
+                      property $ \RandomSql { unRandomSql, fullContents } -> do
+                          emig <- parseSqlMigrationIO "any-name.sql" unRandomSql
+                          case migrationSql <$> emig of
+                              Left _ -> error "Should not be Left!"
+                              Right (WellParsedSql pieces) -> do
+                                  t <- piecesToText <$> Streaming.toList_ pieces
+                                  t `shouldBe` fullContents
+                              Right (UnparsedSql t) ->
+                                  t `shouldBe` fullContents
 
-      it "in-txn and no-txn are mutually exclusive" $ property $ \randomSeed ->
-        do
-          let plainSql = "SOME SQL"
-              sql      = "-- codd: no-txn, in-txn\n" <> plainSql
-          shouldReturnLeft $ parseSqlMigrationIO "any-name.sql" $ mkRandStream
-            randomSeed
-            sql
+            it "in-txn and no-txn are mutually exclusive"
+                $ property
+                $ \randomSeed -> do
+                      let plainSql = "SOME SQL"
+                          sql      = "-- codd: no-txn, in-txn\n" <> plainSql
+                      shouldReturnLeft
+                          $ parseSqlMigrationIO "any-name.sql"
+                          $ mkRandStream randomSeed sql
 
-      it "Gibberish after -- codd:" $ property $ \randomSeed -> do
-        let sql = "-- codd: complete gibberish\n" <> "ANY SQL HERE"
-        mig <- parseSqlMigrationIO "any-name.sql" $ mkRandStream randomSeed sql
-        case mig of
-          Left err ->
-            err `shouldSatisfy`
-                          -- Error message is specific about what is wrong
-                                List.isInfixOf "complete gibberish"
-          Right _ -> expectationFailure "Got Right"
+            it "Gibberish after -- codd:" $ property $ \randomSeed -> do
+                let sql = "-- codd: complete gibberish\n" <> "ANY SQL HERE"
+                mig <- parseSqlMigrationIO "any-name.sql"
+                    $ mkRandStream randomSeed sql
+                case mig of
+                    Left err ->
+                        err `shouldSatisfy`
+                                    -- Error message is specific about what is wrong
+                                            List.isInfixOf "complete gibberish"
+                    Right _ -> expectationFailure "Got Right"
 
-      it "Duplicate options" $ property $ \randomSeed -> do
-        let sql = "-- codd: in-txn, in-txn\n" <> "ANY SQL HERE"
-        mig <- parseSqlMigrationIO "any-name.sql" $ mkRandStream randomSeed sql
-        case mig of
-          Right _   -> expectationFailure "Got Right"
-          Left  err -> err `shouldSatisfy` List.isInfixOf "duplicate"
+            it "Duplicate options" $ property $ \randomSeed -> do
+                let sql = "-- codd: in-txn, in-txn\n" <> "ANY SQL HERE"
+                mig <- parseSqlMigrationIO "any-name.sql"
+                    $ mkRandStream randomSeed sql
+                case mig of
+                    Right _   -> expectationFailure "Got Right"
+                    Left  err -> err `shouldSatisfy` List.isInfixOf "duplicate"
 
-      it "Unknown / mistyped options" $ property $ \randomSeed -> do
-        let sql = "-- codd: unknown-txn\n" <> "ANY SQL HERE"
-        shouldReturnLeft $ parseSqlMigrationIO "any-name.sql" $ mkRandStream
-          randomSeed
-          sql
+            it "Unknown / mistyped options" $ property $ \randomSeed -> do
+                let sql = "-- codd: unknown-txn\n" <> "ANY SQL HERE"
+                shouldReturnLeft
+                    $ parseSqlMigrationIO "any-name.sql"
+                    $ mkRandStream randomSeed sql
 
-      it "Mistyped connection string option" $ property $ \randomSeed -> do
-        let sql = "-- codd-connection: blah\n" <> "ANY SQL HERE"
-        mig <- parseSqlMigrationIO "any-name.sql" $ mkRandStream randomSeed sql
-        case mig of
-          Left err ->
-            -- Nice error message explaining valid format
-            err `shouldSatisfy` ("postgresql.org" `List.isInfixOf`)
-          Right _ -> expectationFailure "Got Right"
+            it "Mistyped connection string option" $ property $ \randomSeed ->
+                do
+                    let sql = "-- codd-connection: blah\n" <> "ANY SQL HERE"
+                    mig <- parseSqlMigrationIO "any-name.sql"
+                        $ mkRandStream randomSeed sql
+                    case mig of
+                        Left err ->
+                          -- Nice error message explaining valid format
+                            err
+                                `shouldSatisfy` ("postgresql.org" `List.isInfixOf`
+                                                )
+                        Right _ -> expectationFailure "Got Right"
 
-      it "Two connection strings" $ property $ \randomSeed -> do
-        let
-          sql =
-            "-- codd-connection: postgres://codd_admin@127.0.0.1:5433/codd-experiments\n"
-              <> "-- codd-connection: postgres://codd_admin@127.0.0.1:5433/codd-experiments\n"
-              <> "ANY SQL HERE"
-        shouldReturnLeft $ parseSqlMigrationIO "any-name.sql" $ mkRandStream
-          randomSeed
-          sql
+            it "Two connection strings" $ property $ \randomSeed -> do
+                let
+                    sql =
+                        "-- codd-connection: postgres://codd_admin@127.0.0.1:5433/codd-experiments\n"
+                            <> "-- codd-connection: postgres://codd_admin@127.0.0.1:5433/codd-experiments\n"
+                            <> "ANY SQL HERE"
+                shouldReturnLeft
+                    $ parseSqlMigrationIO "any-name.sql"
+                    $ mkRandStream randomSeed sql
 
-      it "Two -- codd comments" $ property $ \randomSeed -> do
-        let sql = "-- codd: in-txn\n--codd: in-txn\n" <> "MORE SQL HERE"
-        shouldReturnLeft $ parseSqlMigrationIO "any-name.sql" $ mkRandStream
-          randomSeed
-          sql
+            it "Two -- codd comments" $ property $ \randomSeed -> do
+                let sql =
+                        "-- codd: in-txn\n--codd: in-txn\n" <> "MORE SQL HERE"
+                shouldReturnLeft
+                    $ parseSqlMigrationIO "any-name.sql"
+                    $ mkRandStream randomSeed sql
 
-      it "--codd: no-parse does not mix with -- codd: no-txn"
-        $ property
-        $ \randomSeed -> do
-            let sql = "-- codd: no-parse\n-- codd: no-txn\nSome statement"
-            shouldReturnLeft
-              $ parseSqlMigrationIO "no-parse-migration.sql"
-              $ mkRandStream randomSeed sql
+            it "--codd: no-parse does not mix with -- codd: no-txn"
+                $ property
+                $ \randomSeed -> do
+                      let
+                          sql
+                              = "-- codd: no-parse\n-- codd: no-txn\nSome statement"
+                      shouldReturnLeft
+                          $ parseSqlMigrationIO "no-parse-migration.sql"
+                          $ mkRandStream randomSeed sql
 
-      it "SAVEPOINTs need to be released or rolled back inside SQL migrations"
-        $ pendingWith
-            "Testing this by selecting txid_current() might be more effective"
+            it
+                    "SAVEPOINTs need to be released or rolled back inside SQL migrations"
+                $ pendingWith
+                      "Testing this by selecting txid_current() might be more effective"
 
-    context "Other important behaviours to test" $ do
-      it "Empty queries detector works well" $ property $ \randomSeed -> do
-        let
-          emptyQueries =
-            [ ""
-            , "           "
-            , "      --Some comment           "
-            , "    /* Just comment */ \n"
-            , "      --Some comment    \n-- Some other comment       "
-            , "      --Some comment    \n-- Some other comment\n\n\n       "
-            , "    /* Just comment */ \n -- Other comment \n\n\n\n"
-            , "    /* Just comment */ \n -- Other comment \n\n\n\n"
-            , "\n\n"
-              <> "-- README:\n"
-              <> "-- This is an example of a Migration that renames a column in a Blue-Green-Safe way. Both Old and New Apps\n"
-              <> "-- need not be concerned of the new/old column names here. We recommend caution and testing when using this.\n\n"
-              <> "-- 1. Add the column and set its values, initially\n"
-              <> "-- ALTER TABLE employee ADD COLUMN employee_name TEXT; -- TODO: Remember to set a good DEFAULT if you need one.\n"
-              <> "/* UPDATE employee SET employee_name=name WHERE name IS DISTINCT FROM employee_name; */ \n"
-            ]
-          nonEmptyQueries =
-            [ "      --Some comment    \n-- Some other comment\n\n\n Some SQL Command      "
-            , "      --Some comment    \n-- Some other comment\n\n\n - - This is not a valid comment and should be considered SQL"
-            , "\n\n--Some comment    \n-- Some other comment\n\n\n -- Other comment\n\n\n SQL command"
-            , "SOME SQL COMMAND      --Some comment    \n-- Some other comment\n\n\n - - This is not a valid comment and should be considered SQL"
-            , "Regular sql COMMANDS -- this is a comment"
-            , "Regular sql COMMANDS \n-- this is a comment\n"
-            , "Regular sql /* With comment */ COMMANDS"
-            , "/* With comment */ SQL COMMANDS"
-            , "/* With comment */\n\nSQL COMMANDS\n-- Comment"
-            , "\n\n"
-              <> "-- README:\n"
-              <> "-- This is an example of a Migration that renames a column in a Blue-Green-Safe way. Both Old and New Apps\n"
-              <> "-- need not be concerned of the new/old column names here. We recommend caution and testing when using this.\n\n"
-              <> "-- 1. Add the column and set its values, initially\n"
-              <> "ALTER TABLE employee ADD COLUMN employee_name TEXT; -- TODO: Remember to set a good DEFAULT if you need one.\n"
-              <> "UPDATE employee SET employee_name=name WHERE name IS DISTINCT FROM employee_name;\n"
-            ]
-        forM_ emptyQueries $ \q -> do
-          let
-            parsed =
-              parseSqlPiecesStreaming $ unPureStream $ mkRandStream randomSeed q
-          Streaming.all_ (\p -> isWhiteSpacePiece p || isCommentPiece p) parsed
-            `shouldReturn` True
-        forM_ (nonEmptyQueries ++ map piecesToText validSqlStatements) $ \q ->
-          do
-            let parsed = parseSqlPiecesStreaming $ unPureStream $ mkRandStream
-                  (randomSeed + 1)
-                  q
-            Streaming.any_
-                (\p -> not (isWhiteSpacePiece p || isCommentPiece p))
-                parsed
-              `shouldReturn` True
+        context "Other important behaviours to test" $ do
+            it "Empty queries detector works well" $ property $ \randomSeed ->
+                do
+                    let emptyQueries =
+                            [ ""
+                            , "           "
+                            , "      --Some comment           "
+                            , "    /* Just comment */ \n"
+                            , "      --Some comment    \n-- Some other comment       "
+                            , "      --Some comment    \n-- Some other comment\n\n\n       "
+                            , "    /* Just comment */ \n -- Other comment \n\n\n\n"
+                            , "    /* Just comment */ \n -- Other comment \n\n\n\n"
+                            , "\n\n"
+                                <> "-- README:\n"
+                                <> "-- This is an example of a Migration that renames a column in a Blue-Green-Safe way. Both Old and New Apps\n"
+                                <> "-- need not be concerned of the new/old column names here. We recommend caution and testing when using this.\n\n"
+                                <> "-- 1. Add the column and set its values, initially\n"
+                                <> "-- ALTER TABLE employee ADD COLUMN employee_name TEXT; -- TODO: Remember to set a good DEFAULT if you need one.\n"
+                                <> "/* UPDATE employee SET employee_name=name WHERE name IS DISTINCT FROM employee_name; */ \n"
+                            ]
+                        nonEmptyQueries =
+                            [ "      --Some comment    \n-- Some other comment\n\n\n Some SQL Command      "
+                            , "      --Some comment    \n-- Some other comment\n\n\n - - This is not a valid comment and should be considered SQL"
+                            , "\n\n--Some comment    \n-- Some other comment\n\n\n -- Other comment\n\n\n SQL command"
+                            , "SOME SQL COMMAND      --Some comment    \n-- Some other comment\n\n\n - - This is not a valid comment and should be considered SQL"
+                            , "Regular sql COMMANDS -- this is a comment"
+                            , "Regular sql COMMANDS \n-- this is a comment\n"
+                            , "Regular sql /* With comment */ COMMANDS"
+                            , "/* With comment */ SQL COMMANDS"
+                            , "/* With comment */\n\nSQL COMMANDS\n-- Comment"
+                            , "\n\n"
+                                <> "-- README:\n"
+                                <> "-- This is an example of a Migration that renames a column in a Blue-Green-Safe way. Both Old and New Apps\n"
+                                <> "-- need not be concerned of the new/old column names here. We recommend caution and testing when using this.\n\n"
+                                <> "-- 1. Add the column and set its values, initially\n"
+                                <> "ALTER TABLE employee ADD COLUMN employee_name TEXT; -- TODO: Remember to set a good DEFAULT if you need one.\n"
+                                <> "UPDATE employee SET employee_name=name WHERE name IS DISTINCT FROM employee_name;\n"
+                            ]
+                    forM_ emptyQueries $ \q -> do
+                        let
+                            parsed =
+                                parseSqlPiecesStreaming
+                                    $ unPureStream
+                                    $ mkRandStream randomSeed q
+                        Streaming.all_
+                                (\p -> isWhiteSpacePiece p || isCommentPiece p)
+                                parsed
+                            `shouldReturn` True
+                    forM_
+                            (  nonEmptyQueries
+                            ++ map piecesToText validSqlStatements
+                            )
+                        $ \q -> do
+                              let parsed =
+                                      parseSqlPiecesStreaming
+                                          $ unPureStream
+                                          $ mkRandStream (randomSeed + 1) q
+                              Streaming.any_
+                                      (\p ->
+                                          not
+                                              (  isWhiteSpacePiece p
+                                              || isCommentPiece p
+                                              )
+                                      )
+                                      parsed
+                                  `shouldReturn` True


### PR DESCRIPTION
TODO:
- [x] Golden-tests-like json file with numbers from previous runs that is checked to ensure no big regressions
- [x] Wait to make sure the commit with the right ci.json file passes CI
- [x] Remove INLINE pragmas, push to CI and make sure it fails benchmarks
- [x] Bring INLINE pragmas back.
- [x] Use something other than the average of runtimes to apply regression tests to, since that average includes numbers which are very small and also very large, meaning the bigger numbers simply eclipse the smaller ones.
- [x] Parse COPY lines in batches to minimize roundtrips. Write regression test on the number of SqlPieces.