### PR TITLE
Fix instance indentation

### DIFF
--- a/src/Codd/Parsing.hs
+++ b/src/Codd/Parsing.hs
@@ -147,8 +147,8 @@ instance Monad m => MigrationStream m (PureStream m) where
     migStream PureStream { unPureStream } = unPureStream
 
 instance MonadIO m => MigrationStream m (FileStream m) where
-  -- | Reads entire file from disk again as so to
-  -- be immune to the state of the Stream.
+    -- | Reads entire file from disk again as so to
+    -- be immune to the state of the Stream.
     readFullContents FileStream { filePath } = liftIO $ Text.readFile filePath
     migStream FileStream { fileStream } = fileStream
 


### PR DESCRIPTION
The `MigrationStream m (FileStream m)` instance had a comment that was indented differently from the definitions, causing a "parse error on input" error in some environments.  This change fixes the issue by changing the comment indentation to match that of the definitions.