### PR TITLE
Fix known codd parsing issues and assume standard_conforming_strings is on

### DIFF
--- a/src/Codd/Internal/MultiQueryStatement.hs
+++ b/src/Codd/Internal/MultiQueryStatement.hs
@@ -32,17 +32,6 @@ import           UnliftIO                       ( Exception
                                                 , throwIO
                                                 )
 
--- Multi-query statements are automatically enveloped in a single transaction by the server. This happens because according to
--- https://www.postgresql.org/docs/12/libpq-exec.html, "Multiple queries sent in a single PQexec call are processed in a single transaction,
--- unless there are explicit BEGIN/COMMIT commands included in the query string to divide it into multiple transactions."
--- This creates problem for statements that can't run inside a single transaction (changing enums, creating dbs etc.)
--- Because that seems to be at libpq level, we need to parse SQL (ugh..) and detect plPGSQL bodies and standard SQL to
--- split commands up.. tough situation.
--- Note 1: Maybe alex works to translate psqlscan.l to Haskell? Seems like a rather complicated translation when I look at the source,
--- and I don't know anything about lex/flex/alex.. also, we dong't need to be as good as psql in parsing SQL; we just need to find statement boundaries
--- (psql counts parentheses, for instance) to split them up by that.
--- Note 2: The CLI utility psql does the same and splits up commands before sending them to the server. See https://github.com/postgres/postgres/blob/master/src/fe_utils/psqlscan.l
-
 data SqlStatementException = SqlStatementException
     { sqlStatement :: Text
     , psimpleError :: DB.SqlError

--- a/src/Codd/Parsing.hs
+++ b/src/Codd/Parsing.hs
@@ -13,7 +13,6 @@ module Codd.Parsing
     , isCommentPiece
     , isTransactionEndingPiece
     , isWhiteSpacePiece
-    , mapSqlMigration
     , piecesToText
     , sqlPieceText
     , parsedSqlText
@@ -40,7 +39,7 @@ import           Control.Monad                  ( guard
                                                 , void
                                                 , when
                                                 )
-import           Control.Monad.Identity         ( Identity(runIdentity) )
+import           Control.Monad.Identity         ( Identity(..) )
 import           Control.Monad.Trans            ( MonadTrans
                                                 , lift
                                                 )
@@ -176,13 +175,6 @@ hoistAddedSqlMigration f (AddedSqlMigration sqlMig tst) = AddedSqlMigration
     hoistSqlMig mig = mig { migrationSql = hoistParsedSql $ migrationSql mig }
     hoistParsedSql (UnparsedSql   t     ) = UnparsedSql t
     hoistParsedSql (WellParsedSql stream) = WellParsedSql $ hoist f stream
-
-mapSqlMigration
-    :: (SqlMigration m -> SqlMigration m)
-    -> AddedSqlMigration m
-    -> AddedSqlMigration m
-mapSqlMigration f (AddedSqlMigration sqlMig tst) =
-    AddedSqlMigration (f sqlMig) tst
 
 data SectionOption = OptInTxn Bool | OptNoParse Bool
   deriving stock (Eq, Show)

--- a/src/Codd/Representations/Types.hs
+++ b/src/Codd/Representations/Types.hs
@@ -4,7 +4,6 @@ module Codd.Representations.Types
     , ObjName(..)
     , HasName(..)
     , DiffType(..)
-    -- , Json(..)
     , DbRep(..)
     , SchemaRep(..)
     , TableRep(..)

--- a/test/DbDependentSpecs/ApplicationSpec.hs
+++ b/test/DbDependentSpecs/ApplicationSpec.hs
@@ -17,7 +17,6 @@ import           Codd.Internal.MultiQueryStatement
 import           Codd.Parsing                   ( AddedSqlMigration(..)
                                                 , SqlMigration(..)
                                                 , hoistAddedSqlMigration
-                                                , mapSqlMigration
                                                 )
 import           Codd.Query                     ( unsafeQuery1 )
 import           Codd.Representations           ( readRepresentationsFromDbWithSettings
@@ -162,6 +161,74 @@ createCountCheckingMig expectedCount migName = SqlMigration
     , migrationCustomConnInfo = Nothing
     }
 
+-- | A migration that uses many different ways of inputting strings in postgres. In theory we'd only need to
+-- test the parser, but we do this to sleep well at night too.
+-- This migration only makes sense with standard_conforming_strings=on.
+stdConfStringsMig :: MonadThrow m => AddedSqlMigration m
+stdConfStringsMig = AddedSqlMigration SqlMigration
+    { migrationName = "0001-string-escaping.sql"
+    , migrationSql            =
+        mkValidSql 
+        "create table string_escape_tests (id int not null, t text not null);\n\
+
+\insert into string_escape_tests (id, t) values \n\
+\    (1, 'bc\\def')\n\
+\    -- ^ With standard_confirming_strings=on, the value inserted above should be the Haskell string \"bc\\def\"\n\
+
+\    , (2, E'abc\\def')\n\
+\    -- ^ The value above should _not_ contain the slash, it should be the Haskell string \"abcdef\"\n\
+
+\    , (3, E'abc\\\\def')\n\
+\    -- ^ The value above should be the Haskell string \"abc\\def\"\n\
+
+\    , (4, U&'d\\0061t\\+000061')\n\
+\    -- ^ The value above should be the Haskell string \"data\"\n\
+
+\    , (5, U&'d!0061t!+000061' UESCAPE '!')\n\
+\    -- ^ The value above should also be the Haskell string \"data\"\n\
+
+\    , (6, U&'d;0061t;+000061' UESCAPE ';')\n\
+\    -- ^ The value above should also be the Haskell string \"data\"\n\
+
+\    , (7, U&'d\\0061t\\+000061\\\\''')\n\
+\    -- ^ The value above should also be the Haskell string \"data\\'\"\n\
+
+\    , (8, U&'\\0441\\043B\\043E\\043D')\n\
+\    -- ^ The value above should be the Haskell string \"слон\"\n\
+
+\    , (9, $$Dianne's horse$$)\n\
+\    -- ^ Haskell string \"Dianne's horse\"\n\
+
+\    , (10, $SomeTag$Dianne's horse$SomeTag$)\n\
+\    -- ^ Same as above\n\
+\;"
+    , migrationInTxn          = True
+    , migrationCustomConnInfo = Nothing
+    }
+    (getIncreasingTimestamp 0)
+
+-- | A migration that uses many different ways of inputting strings in postgres. In theory we'd only need to
+-- test the parser, but we do this to sleep well at night too.
+-- This migration only makes sense with standard_conforming_strings=off.
+notStdConfStringsMig :: MonadThrow m => AddedSqlMigration m
+notStdConfStringsMig = AddedSqlMigration SqlMigration
+    { migrationName = "0001-string-escaping.sql"
+    , migrationSql            =
+        mkValidSql 
+        "set standard_conforming_strings=off; create table string_escape_tests (id int not null, t text not null);\n\
+
+\insert into string_escape_tests (id, t) values \n\
+\    (1, 'bc\\def')\n\
+\    -- ^ With standard_confirming_strings=off, the value inserted above should be the Haskell string \"bcdef\"\n\
+
+\    , (2, 'abc\\\\de''f')\n\
+\    -- ^ The value above should _not_ contain the slash, it should be the Haskell string \"abc\\de'f\"\n\
+\;"
+    , migrationInTxn          = True
+    , migrationCustomConnInfo = Nothing
+    }
+    (getIncreasingTimestamp 0)
+
 spec :: Spec
 spec = do
     describe "DbDependentSpecs" $ do
@@ -203,6 +270,43 @@ spec = do
                                           (Just [inTxnMig])
                                           testConnTimeout
                                           (const $ pure ())
+
+                      it "String escaping works in all its forms with standard_conforming_strings=on"
+                          $ \emptyTestDbInfo -> void @IO $ do
+                                stringsAndIds :: [(Int, Text)] <-
+                                    runStdoutLoggingT
+                                    $ applyMigrationsNoCheck
+                                          emptyTestDbInfo
+                                          (Just [stdConfStringsMig])
+                                          testConnTimeout
+                                          (\conn -> liftIO $ DB.query conn "SELECT id, t FROM string_escape_tests ORDER BY id" ())
+
+                                map snd stringsAndIds `shouldBe` [
+                                    "bc\\def"
+                                    , "abcdef"
+                                    , "abc\\def"
+                                    , "data"
+                                    , "data"
+                                    , "data"
+                                    , "data\\'"
+                                    , "слон"
+                                    , "Dianne's horse"
+                                    , "Dianne's horse"
+                                    ]
+                      it "String escaping works in all its forms with standard_conforming_strings=off"
+                          $ \emptyTestDbInfo -> void @IO $ do
+                                stringsAndIds :: [(Int, Text)] <-
+                                    runStdoutLoggingT
+                                    $ applyMigrationsNoCheck
+                                          emptyTestDbInfo
+                                          (Just [notStdConfStringsMig])
+                                          testConnTimeout
+                                          (\conn -> liftIO $ DB.query conn "SELECT id, t FROM string_escape_tests ORDER BY id" ())
+
+                                map snd stringsAndIds `shouldBe` [
+                                    "bcdef"
+                                    , "abc\\de'f"
+                                    ]
 
                       it "COPY FROM STDIN works" $ \emptyTestDbInfo ->
                           runStdoutLoggingT

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -127,8 +127,19 @@ validSqlStatements =
             <> "\nEND;"
             <> "\n$$ LANGUAGE plpgsql;"
             , OtherSqlPiece
-                "select U&'d\\0061t\\+000061', U&'\\0441\\043B\\043E\\043D', U&'d!0061t!+000061' UESCAPE '!', X'1FF', B'1001';"
+                "select U&'d\\0061t\\+000061';"
+            , OtherSqlPiece
+                "select U&'\\0441\\043B\\043E\\043D';"
+            , OtherSqlPiece
+                "select U&'d!0061t!+000061' UESCAPE '!';"
+            -- , OtherSqlPiece
+            --     "select U&'d\\0061t\\+000061' UESCAPE '\\';"
+            , OtherSqlPiece
+                "select X'1FF';"
+            , OtherSqlPiece
+                "select B'1001';"
             , OtherSqlPiece "SELECT 'some''quoted ''string';"
+            , OtherSqlPiece "SELECT E'some\\'quoted string';"
             , OtherSqlPiece "SELECT \"some\"\"quoted identifier\";"
             , OtherSqlPiece
                 "SELECT 'double quotes \" inside single quotes \" - 2';"

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -151,10 +151,9 @@ validSqlStatements =
             , CommitTransaction "COmmIT;"
             , CommitTransaction "COMMIT/*a*/;"
             , CommitTransaction "cOMMIT   ;"
-    -- TODO: Nested C-Style comments (https://www.postgresql.org/docs/9.2/sql-syntax-lexical.html)
-    -- , "/* multiline comment"
-    --   <> "\n  * with nesting: /* nested block comment */"
-    --   <> "\n  */ SELECT 1;"
+        -- Nested C-Style comments (https://www.postgresql.org/docs/9.2/sql-syntax-lexical.html)
+            , CommentPiece "/* multiline comment\n comment */"
+            , CommentPiece "/* nested block /* comment */ still a comment */"
             ]
         ++ [ [ CopyFromStdinStatement
                  "COPY employee FROM STDIN WITH (FORMAT CSV);\n"

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -137,11 +137,24 @@ validSqlStatements =
             , OtherSqlPiece
             $  "$function$"
             <> "\nBEGIN"
-            <> "\n    RETURN ($1 ~ $q$[\t\r\n\v\\]$q$);"
+            <> "\n    RETURN ($1 ~ $q$[\t\r\n\v\\]$q$); /* Some would-be non terminated comment, but it's fine inside dollar quotes"
             <> "\nEND;"
             <> "\n$function$;"
             , OtherSqlPiece "SELECT COALESCE(4, 1 - 2) - 3 + 4 - 5;"
             , OtherSqlPiece "SELECT (1 - 4) / 5 * 3 / 9.1;"
+            -- Semi-colons inside parenthesised blocks are not statement boundaries
+            , OtherSqlPiece
+                "create rule name as on some_event to some_table do (command1; command2; command3;);"
+            -- String blocks can be opened inside parentheses, just like comments, dollar-quoted strings and others
+            , OtherSqlPiece
+                "create rule name as on some_event to some_table do ('abcdef);'; other;);"
+            , OtherSqlPiece
+                "some statement with spaces (((U&'d\\0061t\\+000061', 'abc''def' ; ; ; /* comment /* nested */ ((( */ $hey$dollar string$hey$)) 'more''of'; this; ());"
+            , OtherSqlPiece
+                "select 'unclosed parentheses inside string (((((', (('string (('));"
+            -- We still want the following to be parsed; it's best to run invalid statements than have
+            -- a parser so strict that it might refuse valid ones.
+            , OtherSqlPiece "invalid statement, bad parentheses ()));"
             , BeginTransaction "begin;"
             , BeginTransaction "BEGiN/*a*/;"
             , BeginTransaction "BEgIN   ;"

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -105,6 +105,7 @@ validSqlStatements =
                 "SELECT E'so\\'; \\; m -- c-style string, (( not a comment \\\\ \\abc' FROM ahahaha;"
             , OtherSqlPiece
                 "SELECT E'Consecutive single quotes are also escaped here ''; see?';"
+            , OtherSqlPiece "SELECT E'''20s' = E'\\'20s';"
             , OtherSqlPiece
             $  "DO"
             <> "\n$do$"
@@ -136,8 +137,7 @@ validSqlStatements =
             , OtherSqlPiece "select U&'d\\0061t\\+000061';"
             , OtherSqlPiece "select U&'\\0441\\043B\\043E\\043D';"
             , OtherSqlPiece "select U&'d!0061t!+000061' UESCAPE '!';"
-            -- , OtherSqlPiece
-            --     "select U&'d\\0061t\\+000061' UESCAPE '\\';"
+            , OtherSqlPiece "select U&'d\\0061t\\+000061' UESCAPE '\\';"
             , OtherSqlPiece "select X'1FF';"
             , OtherSqlPiece "select B'1001';"
             , OtherSqlPiece "SELECT 'some''quoted ''string';"


### PR DESCRIPTION
Fixes #153.

The parser will fail for users who have standard_conforming_strings=off, but the previous/current parser would fail for standard_conforming_strings=on (in some cases). I'll create a separate issue for that, as standard_conforming_strings can be changed inside a migration, meaning it should be part of parsing state.

TODO:
- ~We probably should support standard_conforming_strings=off in this same PR, even if we don't support changes to its value inside migrations. It's not absurd that some users that have been using postgres for a while have legacy code that they never cared to migrate, since it's so easy to change this setting.~

It would indeed be nice to support standard_conforming_strings=off in this PR, but the default has been `on` for very long now and we don't support that in the current version, so this PR should statistically be an improvement. Also, it's not so easy to properly support `standard_conforming_strings`, since we need to parse the headers of migrations before we have an open connection to the database in some cases, and `standard_conforming_strings` is in fact database-dependent, meaning different migrations would have to be parsed differently. At that point, we might as well import `psqlscan.l` and use the upstream parser once and for all.