### PR TITLE
Clean up warnings in test code and inline function in Internal.hs

### DIFF
--- a/test/DbDependentSpecs/AnalysisSpec.hs
+++ b/test/DbDependentSpecs/AnalysisSpec.hs
@@ -3,22 +3,15 @@ module DbDependentSpecs.AnalysisSpec where
 import           Codd.Analysis                  ( MigrationCheck(..)
                                                 , checkMigration
                                                 )
-import           Codd.Environment               ( CoddSettings(..) )
 import           Codd.Parsing                   ( AddedSqlMigration(..)
                                                 , SqlMigration(..)
                                                 )
 import           Control.Monad                  ( (>=>)
                                                 , forM_
                                                 , void
-                                                , when
                                                 )
 import           Control.Monad.Trans.Resource   ( MonadThrow )
-import           Data.Maybe                     ( isJust )
-import           Data.Text                      ( unpack )
-import qualified Database.PostgreSQL.Simple    as DB
-import           Database.PostgreSQL.Simple     ( ConnectInfo(..) )
-import           DbUtils                        ( aroundDatabaseWithMigs
-                                                , getIncreasingTimestamp
+import           DbUtils                        ( getIncreasingTimestamp
                                                 , mkValidSql
                                                 )
 import           Test.Hspec

--- a/test/DbDependentSpecs/AppCommandsSpec.hs
+++ b/test/DbDependentSpecs/AppCommandsSpec.hs
@@ -51,7 +51,7 @@ migThatWontRun = AddedSqlMigration
     (getIncreasingTimestamp 99999)
 
 doesNotCreateDB :: (CoddSettings -> LoggingT IO a) -> IO ()
-doesNotCreateDB act = do
+doesNotCreateDB _act = do
     vanillaTestSettings <- testCoddSettings
     let testSettings = vanillaTestSettings
             { onDiskReps     = Right $ DbRep Aeson.Null Map.empty Map.empty

--- a/test/DbDependentSpecs/InvariantsSpec.hs
+++ b/test/DbDependentSpecs/InvariantsSpec.hs
@@ -1,8 +1,5 @@
 module DbDependentSpecs.InvariantsSpec where
 
-import           Codd.Analysis                  ( MigrationCheck(..)
-                                                , checkMigration
-                                                )
 import           Codd.Environment               ( CoddSettings(..) )
 import           Codd.Internal                  ( withConnection )
 import           Codd.Logging                   ( runCoddLogger )
@@ -10,24 +7,16 @@ import           Codd.Parsing                   ( AddedSqlMigration(..)
                                                 , SqlMigration(..)
                                                 , toMigrationTimestamp
                                                 )
-import           Codd.Representations           ( readRepresentationsFromDbWithSettings
-                                                )
 import           Codd.Representations.Database  ( readRepsFromDbWithNewTxn )
-import           Control.Monad                  ( void
-                                                , when
-                                                )
+import           Control.Monad                  ( void )
 import           Control.Monad.Trans.Resource   ( MonadThrow )
 import           Data.List                      ( nubBy )
-import           Data.Text                      ( unpack )
 import           Data.Time.Calendar             ( fromGregorian )
 import           Data.Time.Clock                ( UTCTime(..) )
 import qualified Database.PostgreSQL.Simple    as DB
-import           Database.PostgreSQL.Simple     ( ConnectInfo(..) )
 import qualified Database.PostgreSQL.Simple.Time
                                                as DB
 import           DbUtils                        ( aroundDatabaseWithMigs
-                                                , aroundFreshDatabase
-                                                , aroundTestDbInfo
                                                 , getIncreasingTimestamp
                                                 , mkValidSql
                                                 , shouldBeStrictlySortedOn
@@ -75,7 +64,7 @@ spec = do
                 $
                     -- This is much more a test of postgresql-simple than Codd. But it's such an important property to know that holds
                     -- that we test for it here anyway.
-                  \dbInfo@CoddSettings { migsConnString } ->
+                  \CoddSettings { migsConnString } ->
                       let
                           veryCloseUtcTimes =
                               zip [0 ..]

--- a/test/EnvironmentSpec.hs
+++ b/test/EnvironmentSpec.hs
@@ -9,15 +9,10 @@ import           Codd.Representations.Types     ( ObjName(..) )
 import           Codd.Types                     ( RetryBackoffPolicy(..)
                                                 , RetryPolicy(..)
                                                 )
-import           Control.Monad                  ( forM_
-                                                , when
-                                                )
-import           Data.Align                     ( alignWith )
 import           Data.Attoparsec.Text           ( endOfInput
                                                 , parseOnly
                                                 )
 import           Data.Either                    ( isLeft )
-import           Data.Functor                   ( (<&>) )
 import           Data.Hashable                  ( hash )
 import           Data.List                      ( sortOn )
 import           Data.Maybe                     ( catMaybes )
@@ -26,7 +21,6 @@ import           Data.Text                      ( Text )
 import           Data.Time                      ( secondsToDiffTime )
 import           Data.Word                      ( Word16 )
 import           Database.PostgreSQL.Simple     ( ConnectInfo(..) )
-import           GHC.Generics                   ( Generic )
 import           Network.URI                    ( URI(..)
                                                 , URIAuth(..)
                                                 , escapeURIString
@@ -34,7 +28,6 @@ import           Network.URI                    ( URI(..)
                                                 , uriToString
                                                 )
 import           Test.Hspec
-import           Test.Hspec.Core.QuickCheck     ( modifyMaxSuccess )
 import           Test.QuickCheck
 import           TypesGen                       ( genObjName )
 
@@ -310,7 +303,9 @@ spec = do
                     `shouldBe` Right
                                    (RetryPolicy
                                        2
-                                       (ExponentialBackoff (realToFrac 2.5))
+                                       (ExponentialBackoff
+                                           (realToFrac @Double 2.5)
+                                       )
                                    )
 
                 parseOnly (retryPolicyParser <* endOfInput)
@@ -318,5 +313,7 @@ spec = do
                     `shouldBe` Right
                                    (RetryPolicy
                                        7
-                                       (ConstantBackoff (realToFrac 1.25))
+                                       (ConstantBackoff
+                                           (realToFrac @Double 1.25)
+                                       )
                                    )

--- a/test/LiftedExpectations.hs
+++ b/test/LiftedExpectations.hs
@@ -2,8 +2,7 @@ module LiftedExpectations
     ( shouldThrow
     ) where
 
-import           Test.Hspec                     ( Expectation
-                                                , HasCallStack
+import           Test.Hspec                     ( HasCallStack
                                                 , Selector
                                                 )
 import qualified Test.Hspec                    as Hspec

--- a/test/SystemResourcesSpecs/OpenFilesSpec.hs
+++ b/test/SystemResourcesSpecs/OpenFilesSpec.hs
@@ -14,14 +14,12 @@ import           Control.Monad.Trans.Resource   ( MonadThrow(..) )
 import qualified Data.Attoparsec.Text          as P
 import qualified Data.Char                     as Char
 import qualified Data.Map.Strict               as Map
-import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import qualified Data.Text.IO                  as Text
 import           DbUtils                        ( aroundFreshDatabase
                                                 , testConnTimeout
                                                 )
 import           Test.Hspec
-import           Test.Hspec.Expectations
 import           UnliftIO                       ( SomeException
                                                 , try
                                                 )
@@ -120,7 +118,7 @@ spec = do
 -- | Parses both glibc's `openat` and musl's `open` syscalls from a `strace -f -o` output line and returns the opened file and file descriptor.
 openParser :: P.Parser (FilePath, Int)
 openParser = do
-    void P.decimal
+    void $ P.decimal @Int
     P.skipWhile Char.isSpace
     void $ P.string "openat(AT_FDCWD, \"" <|> P.string "open(\"" -- glibc and musl use different syscalls. The former is glibc's and the latter is musl's.
     fp <- P.takeWhile1 ('"' /=)
@@ -131,14 +129,14 @@ openParser = do
     P.skipWhile Char.isSpace
     void $ P.string "="
     P.skipWhile Char.isSpace
-    fd <- P.decimal
+    fd <- P.decimal @Int
     pure (Text.unpack fp, fd)
 
 
 -- | Parses a `close` strace output line and returns the closed file descriptor.
 closeParser :: P.Parser Int
 closeParser = do
-    void P.decimal
+    void $ P.decimal @Int
     P.skipWhile Char.isSpace
     void $ P.string "close("
     fd <- P.decimal

--- a/test/TxnConstraintsSpecs/ValidConstructsSpec.hs
+++ b/test/TxnConstraintsSpecs/ValidConstructsSpec.hs
@@ -10,7 +10,6 @@ import           Codd.Query                     ( InTxn
                                                 , withTransaction
                                                 )
 import           Codd.Types                     ( TxnIsolationLvl(..) )
-import           Control.Monad.IO.Class         ( MonadIO(..) )
 import qualified Database.PostgreSQL.Simple    as DB
 import           Test.Hspec
 import           UnliftIO                       ( MonadUnliftIO )

--- a/test/TypesGen.hs
+++ b/test/TypesGen.hs
@@ -2,7 +2,6 @@ module TypesGen where
 
 import           AesonValueGen                  ( )
 import           Codd.Representations
-import           Data.Aeson                     ( Value )
 import           Data.Function                  ( on )
 import           Data.List                      ( nubBy )
 import qualified Data.Map.Strict               as Map

--- a/test/WritingReadingRepresentationsSpec.hs
+++ b/test/WritingReadingRepresentationsSpec.hs
@@ -4,9 +4,7 @@ import           Codd.Representations           ( persistRepsToDisk
                                                 , readRepsFromDisk
                                                 , schemaDifferences
                                                 )
-import           Control.Monad                  ( when )
 import qualified Data.Map                      as Map
-import           Data.Text                      ( unpack )
 import           Test.Hspec
 import           Test.Hspec.Core.QuickCheck     ( modifyMaxSuccess )
 import           Test.QuickCheck


### PR DESCRIPTION
The function was only called from one other function, and it had no reasonable human understandable meaning by itself.