### PR TITLE
Add index validity to representations and conservatively disregard non-persistent relations

### DIFF
--- a/expected-schema/schemas/public/tables/animals/indexes/animals_pkey
+++ b/expected-schema/schemas/public/tables/animals/indexes/animals_pkey
@@ -16,5 +16,6 @@
     "rowsecurity": false,
     "rowtype": null,
     "shared": false,
-    "unique": true
+    "unique": true,
+    "valid": true
 }

--- a/expected-schema/schemas/public/tables/animals/statistics/test_stat_with_expr
+++ b/expected-schema/schemas/public/tables/animals/statistics/test_stat_with_expr
@@ -6,7 +6,5 @@
         "f",
         "m"
     ],
-    "namespace": "public",
-    "owner": "codd_admin",
-    "table": "animals"
+    "owner": "codd_admin"
 }

--- a/expected-schema/schemas/public/tables/employee/indexes/any_unique_employee_idx_will_do
+++ b/expected-schema/schemas/public/tables/employee/indexes/any_unique_employee_idx_will_do
@@ -16,5 +16,6 @@
     "rowsecurity": false,
     "rowtype": null,
     "shared": false,
-    "unique": true
+    "unique": true,
+    "valid": true
 }

--- a/expected-schema/schemas/public/tables/employee/indexes/employee_pkey
+++ b/expected-schema/schemas/public/tables/employee/indexes/employee_pkey
@@ -16,5 +16,6 @@
     "rowsecurity": false,
     "rowtype": null,
     "shared": false,
-    "unique": true
+    "unique": true,
+    "valid": true
 }

--- a/expected-schema/schemas/public/tables/employee/statistics/test_stat
+++ b/expected-schema/schemas/public/tables/employee/statistics/test_stat
@@ -5,7 +5,5 @@
         "f",
         "m"
     ],
-    "namespace": "public",
-    "owner": "codd_admin",
-    "table": "employee"
+    "owner": "codd_admin"
 }

--- a/expected-schema/schemas/public/tables/employee/statistics/test_stat_expr
+++ b/expected-schema/schemas/public/tables/employee/statistics/test_stat_expr
@@ -5,7 +5,5 @@
         "f",
         "m"
     ],
-    "namespace": "public",
-    "owner": "codd_admin",
-    "table": "employee"
+    "owner": "codd_admin"
 }

--- a/src/Codd/Representations/Database/Pg14.hs
+++ b/src/Codd/Representations/Database/Pg14.hs
@@ -117,7 +117,7 @@ objRepQueryFor allRoles allSchemas schemaAlgoOpts schemaName tableName hobj =
                         "proowner"
                         "proacl"
                       <> "_codd_roles_without_grantors ON TRUE",
-                  nonIdentWhere = Nothing,
+                  nonIdentWhere = nonIdentWhere hq,
                   identWhere =
                     Just $
                       "TRUE"
@@ -134,9 +134,7 @@ objRepQueryFor allRoles allSchemas schemaAlgoOpts schemaName tableName hobj =
           -- did not exist in the previous version
           hq
             { repCols =
-                [ ("table", "pg_class.relname"),
-                  ("namespace", "pg_namespace.nspname"),
-                  ("owner", "pg_roles.rolname"),
+                [ ("owner", "pg_roles.rolname"),
                   ("kind", Pg12.sortArrayExpr "stxkind"),
                   ( "definition",
                     "pg_catalog.pg_get_statisticsobjdef_columns(pg_statistic_ext.oid)"


### PR DESCRIPTION
Summary: this PR adds code that is bit more defensive towards filtering out temporary tables, indexes and other temporary database objects, to avoid what _might_ be considered a bug in postgres. The bug seems to only happen if users are applying DDL _while_ codd is verifying (or writing) schemas, so it should be rare and we can tell users not to do this.

There is more that we could do to prevent this error, like use `MATERIALIZED` CTEs that filter out temporary tables without calling catalog functions. I'll leave that to the future when I hopefully have more clarity on what happens in postgres.

More details about the error below.

---

The following script drops a table concurrently to a query that queries the pg catalog, and runs into an error.

```bash
#!/usr/bin/env bash

psql -c "create table test(x serial primary key); select oid, relname from pg_class where relname='test'"
# The next two queries will run concurrently
psql -c "select oid, relname, pg_sleep(3), pg_get_indexdef(oid) from pg_class join pg_index on indexrelid=pg_class.oid WHERE relname='test_pkey';" 2>&1 1>/tmp/pgbug.log &
sleep 1
psql -c "drop table test"
cat /tmp/pgbug.log
wait
```

This most often does not fail, but some times it does with an error like:
```
ERROR:  could not open relation with OID 169711
```

The OID is of the dropped table.

Where this could be annoying is if this happens even with e.g. temporary tables. Codd ignores those, but it's not inconceivable that with lateral joins and depending on the query plan, postgres calls e.g. `pg_get_indexdef` or other functions before the filter on `relpersistence` is applied, and that leads to an error. I'm still not sure how this can happen since codd runs inside a transaction, but presumably the first query inside the transaction is where a snapshot is acquired (and how ACID-compliant are pg_catalog tables? I don't know) and is where this could still happen.

Also, this _might_ be considered a bug in postgres as one might argue that the index is listed in `pg_index` so at the time the statement runs the catalog tables are still populated with the index and table, and yet `pg_get_indexdef` errors out.

I posted a question to the pg-general mailing list about this: https://www.postgresql.org/message-id/CACgY3QYe3mqMkODOzwx%3DEN4iGoddObUotLL8hGnCg%3D%3D3vmxd_g%40mail.gmail.com