### PR TITLE
Better on-disk representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ psql -c "SELECT popular_name FROM animals"
 $ psql -c "ALTER TABLE animals ALTER COLUMN popular_name TYPE VARCHAR(30)"
 ALTER TABLE
 $ codd verify-schema
-Error: DB and expected schemas do not match. Differing objects and their current DB schemas are: {"schemas/public/tables/animals/cols/popular_name":["different-schemas",{"collation":"default","collation_nsp":"pg_catalog","default":null,"generated":"","hasdefault":false,"identity":"","inhcount":0,"local":true,"notnull":true,"order":2,"privileges":null,"type":"varchar","typmod":34}]}
+Error: DB and expected schemas do not match. Differing objects and their current DB schemas are: {"schemas/public/tables/animals/cols/popular_name":["different-schemas",{"collation":"default","collation_nsp":"pg_catalog","default":null,"generated":"","hasdefault":false,"identity":"","inhcount":0,"local":true,"notnull":true,"privileges":null,"type":"character varying(30)"}],"schemas/public/tables/animals/statistics/test_stat_with_expr":["different-schemas",{"definition":"id, popular_name, lower(popular_name::text), (id * 42)","kind":["d","e","f","m"],"owner":"codd_admin"}]}
 ````
 
 </td>
@@ -94,6 +94,18 @@ $ git merge branch-with-conflicting-db-migration
 Auto-merging expected-schema/schemas/public/tables/animals/cols/popular_name
 CONFLICT (content): Merge conflict in expected-schema/schemas/public/tables/animals/cols/popular_name
 Automatic merge failed; fix conflicts and then commit the result.
+````
+
+</td>
+</tr>
+
+<tr>
+<td>Useful diffs</td>
+<td>
+
+````diff
+- "definition": "CHECK (value >= 0::numeric)",
++ "definition": "CHECK (value > 0::numeric)",
 ````
 
 </td>

--- a/expected-schema/schemas/public/routines/floatmultirange;
+++ b/expected-schema/schemas/public/routines/floatmultirange;
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/floatmultirange;_floatrange
+++ b/expected-schema/schemas/public/routines/floatmultirange;_floatrange
@@ -5,7 +5,7 @@
     "argnames": null,
     "args": "VARIADIC public.floatrange[]",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/floatmultirange;floatrange
+++ b/expected-schema/schemas/public/routines/floatmultirange;floatrange
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "public.floatrange",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/floatrange;float8,float8
+++ b/expected-schema/schemas/public/routines/floatrange;float8,float8
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "double precision, double precision",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/floatrange;float8,float8,text
+++ b/expected-schema/schemas/public/routines/floatrange;float8,float8,text
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "double precision, double precision, text",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/time_subtype_diff;time,time
+++ b/expected-schema/schemas/public/routines/time_subtype_diff;time,time
@@ -6,7 +6,7 @@
     ],
     "args": "x time without time zone, y time without time zone",
     "config": null,
-    "definition_md5": "c537e192bed99154c059e7da6626c528",
+    "definition": "SELECT EXTRACT(EPOCH FROM (x - y))",
     "kind": "f",
     "lang": "sql",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/timemultirange;
+++ b/expected-schema/schemas/public/routines/timemultirange;
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/timemultirange;_timerange
+++ b/expected-schema/schemas/public/routines/timemultirange;_timerange
@@ -5,7 +5,7 @@
     "argnames": null,
     "args": "VARIADIC public.timerange[]",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/timemultirange;timerange
+++ b/expected-schema/schemas/public/routines/timemultirange;timerange
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "public.timerange",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/timerange;time,time
+++ b/expected-schema/schemas/public/routines/timerange;time,time
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "time without time zone, time without time zone",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/routines/timerange;time,time,text
+++ b/expected-schema/schemas/public/routines/timerange;time,time,text
@@ -3,7 +3,7 @@
     "argnames": null,
     "args": "time without time zone, time without time zone, text",
     "config": null,
-    "definition_md5": null,
+    "definition": null,
     "kind": "f",
     "lang": "internal",
     "leakproof": false,

--- a/expected-schema/schemas/public/tables/animals/cols/id
+++ b/expected-schema/schemas/public/tables/animals/cols/id
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 1,
     "privileges": null,
-    "type": "int4",
-    "typmod": -1
+    "type": "integer"
 }

--- a/expected-schema/schemas/public/tables/animals/cols/id
+++ b/expected-schema/schemas/public/tables/animals/cols/id
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 1,
     "privileges": null,
     "type": "integer"
 }

--- a/expected-schema/schemas/public/tables/animals/cols/popular_name
+++ b/expected-schema/schemas/public/tables/animals/cols/popular_name
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 2,
     "privileges": null,
-    "type": "text",
-    "typmod": -1
+    "type": "text"
 }

--- a/expected-schema/schemas/public/tables/animals/cols/popular_name
+++ b/expected-schema/schemas/public/tables/animals/cols/popular_name
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 2,
     "privileges": null,
     "type": "text"
 }

--- a/expected-schema/schemas/public/tables/animals/objrep
+++ b/expected-schema/schemas/public/tables/animals/objrep
@@ -1,6 +1,10 @@
 {
     "accessmethod": "heap",
     "amoptions": null,
+    "columns_in_order": [
+        "id",
+        "popular_name"
+    ],
     "compositetype": null,
     "forcerowsecurity": false,
     "kind": "r",

--- a/expected-schema/schemas/public/tables/employee/cols/employee_id
+++ b/expected-schema/schemas/public/tables/employee/cols/employee_id
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 1,
     "privileges": null,
-    "type": "int4",
-    "typmod": -1
+    "type": "integer"
 }

--- a/expected-schema/schemas/public/tables/employee/cols/employee_id
+++ b/expected-schema/schemas/public/tables/employee/cols/employee_id
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 1,
     "privileges": null,
     "type": "integer"
 }

--- a/expected-schema/schemas/public/tables/employee/cols/employee_name
+++ b/expected-schema/schemas/public/tables/employee/cols/employee_name
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 2,
     "privileges": null,
-    "type": "text",
-    "typmod": -1
+    "type": "text"
 }

--- a/expected-schema/schemas/public/tables/employee/cols/employee_name
+++ b/expected-schema/schemas/public/tables/employee/cols/employee_name
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 2,
     "privileges": null,
     "type": "text"
 }

--- a/expected-schema/schemas/public/tables/employee/cols/experience
+++ b/expected-schema/schemas/public/tables/employee/cols/experience
@@ -10,6 +10,5 @@
     "notnull": false,
     "order": 3,
     "privileges": null,
-    "type": "experience",
-    "typmod": -1
+    "type": "public.experience"
 }

--- a/expected-schema/schemas/public/tables/employee/cols/experience
+++ b/expected-schema/schemas/public/tables/employee/cols/experience
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": false,
-    "order": 3,
     "privileges": null,
     "type": "public.experience"
 }

--- a/expected-schema/schemas/public/tables/employee/cols/surname
+++ b/expected-schema/schemas/public/tables/employee/cols/surname
@@ -10,6 +10,5 @@
     "notnull": false,
     "order": 4,
     "privileges": null,
-    "type": "text",
-    "typmod": -1
+    "type": "text"
 }

--- a/expected-schema/schemas/public/tables/employee/cols/surname
+++ b/expected-schema/schemas/public/tables/employee/cols/surname
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": false,
-    "order": 4,
     "privileges": null,
     "type": "text"
 }

--- a/expected-schema/schemas/public/tables/employee/objrep
+++ b/expected-schema/schemas/public/tables/employee/objrep
@@ -1,6 +1,12 @@
 {
     "accessmethod": "heap",
     "amoptions": null,
+    "columns_in_order": [
+        "employee_id",
+        "employee_name",
+        "experience",
+        "surname"
+    ],
     "compositetype": null,
     "forcerowsecurity": false,
     "kind": "r",

--- a/expected-schema/schemas/public/tables/no_cols_table/objrep
+++ b/expected-schema/schemas/public/tables/no_cols_table/objrep
@@ -1,6 +1,7 @@
 {
     "accessmethod": "heap",
     "amoptions": null,
+    "columns_in_order": [],
     "compositetype": null,
     "forcerowsecurity": false,
     "kind": "r",

--- a/expected-schema/schemas/public/tables/people/objrep
+++ b/expected-schema/schemas/public/tables/people/objrep
@@ -1,6 +1,7 @@
 {
     "accessmethod": "heap",
     "amoptions": null,
+    "columns_in_order": [],
     "compositetype": null,
     "forcerowsecurity": false,
     "kind": "r",

--- a/expected-schema/schemas/public/tables/table_created_with_no_parse_mig/objrep
+++ b/expected-schema/schemas/public/tables/table_created_with_no_parse_mig/objrep
@@ -1,6 +1,7 @@
 {
     "accessmethod": "heap",
     "amoptions": null,
+    "columns_in_order": [],
     "compositetype": null,
     "forcerowsecurity": false,
     "kind": "r",

--- a/expected-schema/schemas/public/tables/transactions/cols/anonymous
+++ b/expected-schema/schemas/public/tables/transactions/cols/anonymous
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 5,
     "privileges": null,
     "type": "boolean"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/anonymous
+++ b/expected-schema/schemas/public/tables/transactions/cols/anonymous
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 5,
     "privileges": null,
-    "type": "bool",
-    "typmod": -1
+    "type": "boolean"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/id
+++ b/expected-schema/schemas/public/tables/transactions/cols/id
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 1,
     "privileges": null,
     "type": "bigint"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/id
+++ b/expected-schema/schemas/public/tables/transactions/cols/id
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 1,
     "privileges": null,
-    "type": "int8",
-    "typmod": -1
+    "type": "bigint"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/payer
+++ b/expected-schema/schemas/public/tables/transactions/cols/payer
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 2,
     "privileges": null,
-    "type": "text",
-    "typmod": -1
+    "type": "text"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/payer
+++ b/expected-schema/schemas/public/tables/transactions/cols/payer
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 2,
     "privileges": null,
     "type": "text"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/receiver
+++ b/expected-schema/schemas/public/tables/transactions/cols/receiver
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": true,
-    "order": 3,
     "privileges": null,
     "type": "text"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/receiver
+++ b/expected-schema/schemas/public/tables/transactions/cols/receiver
@@ -10,6 +10,5 @@
     "notnull": true,
     "order": 3,
     "privileges": null,
-    "type": "text",
-    "typmod": -1
+    "type": "text"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/value
+++ b/expected-schema/schemas/public/tables/transactions/cols/value
@@ -10,6 +10,5 @@
     "notnull": false,
     "order": 4,
     "privileges": null,
-    "type": "numeric",
-    "typmod": 655366
+    "type": "numeric(10,2)"
 }

--- a/expected-schema/schemas/public/tables/transactions/cols/value
+++ b/expected-schema/schemas/public/tables/transactions/cols/value
@@ -8,7 +8,6 @@
     "inhcount": 0,
     "local": true,
     "notnull": false,
-    "order": 4,
     "privileges": null,
     "type": "numeric(10,2)"
 }

--- a/expected-schema/schemas/public/tables/transactions/constraints/transactions_value_check
+++ b/expected-schema/schemas/public/tables/transactions/constraints/transactions_value_check
@@ -1,7 +1,7 @@
 {
     "deferrable": false,
     "deferred": false,
-    "definition": "CHECK ((value > (0)::numeric))",
+    "definition": "CHECK (value > 0::numeric)",
     "fk_deltype": " ",
     "fk_matchtype": " ",
     "fk_ref_table": null,

--- a/expected-schema/schemas/public/tables/transactions/objrep
+++ b/expected-schema/schemas/public/tables/transactions/objrep
@@ -1,6 +1,13 @@
 {
     "accessmethod": "heap",
     "amoptions": null,
+    "columns_in_order": [
+        "id",
+        "payer",
+        "receiver",
+        "value",
+        "anonymous"
+    ],
     "compositetype": null,
     "forcerowsecurity": false,
     "kind": "r",

--- a/expected-schema/schemas/public/types/non_empty_text
+++ b/expected-schema/schemas/public/types/non_empty_text
@@ -4,7 +4,7 @@
     "collation_nsp": "pg_catalog",
     "comp_type_table": null,
     "composite_type_attrs": "",
-    "constraints": "false;new_constraint;CHECK ((VALUE <> 'empty'::text)) NOT VALID;true;non_empty_text_check;CHECK ((VALUE <> ''::text))",
+    "constraints": "false;new_constraint;CHECK (VALUE <> 'empty'::text) NOT VALID;true;non_empty_text_check;CHECK (VALUE <> ''::text)",
     "default": null,
     "delim": ",",
     "domain_basetype": "text",

--- a/expected-schema/schemas/public/types/non_whitespace_text
+++ b/expected-schema/schemas/public/types/non_whitespace_text
@@ -4,7 +4,7 @@
     "collation_nsp": "pg_catalog",
     "comp_type_table": null,
     "composite_type_attrs": "",
-    "constraints": "true;non_whitespace_text_check;CHECK ((TRIM(BOTH FROM VALUE) <> ''::text))",
+    "constraints": "true;non_whitespace_text_check;CHECK (TRIM(BOTH FROM VALUE) <> ''::text)",
     "default": null,
     "delim": ",",
     "domain_basetype": "text",

--- a/src/Codd/Representations/Database/Pg12.hs
+++ b/src/Codd/Representations/Database/Pg12.hs
@@ -492,7 +492,7 @@ objRepQueryFor allRoles schemaSel schemaAlgoOpts schemaName tableName = \case
     DbObjRepresentationQuery
       { objNameCol = "attname",
         repCols =
-          [ ("type", "pg_type.typname"),
+          [ ("type", "pg_catalog.format_type(atttypid, atttypmod)"),
             ("notnull", "attnotnull"),
             ("hasdefault", "atthasdef"),
             ( "default",
@@ -501,7 +501,6 @@ objRepQueryFor allRoles schemaSel schemaAlgoOpts schemaName tableName = \case
             ("identity", "attidentity"),
             ("local", "attislocal"),
             ("inhcount", "attinhcount"),
-            ("typmod", "atttypmod"),
             ("collation", "pg_collation.collname"),
             ("collation_nsp", "collation_namespace.nspname"),
             ("privileges", "_codd_roles.permissions"),
@@ -522,7 +521,6 @@ objRepQueryFor allRoles schemaSel schemaAlgoOpts schemaName tableName = \case
         joins =
           "JOIN pg_catalog.pg_class ON pg_class.oid=attrelid"
             <> "\nJOIN pg_catalog.pg_namespace ON pg_namespace.oid=pg_class.relnamespace"
-            <> "\nLEFT JOIN pg_catalog.pg_type ON pg_type.oid=atttypid"
             <> "\nLEFT JOIN pg_catalog.pg_attrdef ON pg_attrdef.adrelid=pg_class.oid AND pg_attrdef.adnum=pg_attribute.attnum"
             <> "\nLEFT JOIN pg_collation ON pg_collation.oid=pg_attribute.attcollation"
             <> "\nLEFT JOIN pg_namespace collation_namespace ON pg_collation.collnamespace=collation_namespace.oid"

--- a/src/Codd/Representations/Database/Pg12.hs
+++ b/src/Codd/Representations/Database/Pg12.hs
@@ -424,8 +424,8 @@ objRepQueryFor allRoles schemaSel schemaAlgoOpts schemaName tableName = \case
             -- is compiled, so we ignore this column in those cases.
             -- Note that this means that functions with different implementations could be considered equal,
             -- but I don't know a good way around this
-            ( "definition_md5",
-              "CASE WHEN pg_language.lanispl OR pg_language.lanname IN ('sql', 'plpgsql') THEN MD5(prosrc) END"
+            ( "definition",
+              "CASE WHEN pg_language.lanispl OR pg_language.lanname IN ('sql', 'plpgsql') THEN prosrc END"
             ),
             ("kind", "prokind")
             -- Only include the owner of the function if this

--- a/src/Codd/Representations/Database/Pg12.hs
+++ b/src/Codd/Representations/Database/Pg12.hs
@@ -560,7 +560,7 @@ objRepQueryFor allRoles schemaSel schemaAlgoOpts schemaName tableName = \case
             -- referenced columns' names, AND because attnum is affected by dropped columns.
             --   , "pg_constraint.conkey"
             --   , "pg_constraint.confkey"
-            ("definition", "pg_get_constraintdef(pg_constraint.oid)"),
+            ("definition", "pg_get_constraintdef(pg_constraint.oid, true)"),
             ( "parent_constraint",
               "pg_parent_constraint.conname"
             )
@@ -729,7 +729,7 @@ objRepQueryFor allRoles schemaSel schemaAlgoOpts schemaName tableName = \case
                        "ARRAY_TO_STRING(ARRAY_AGG(pg_enum.enumlabel::TEXT ORDER BY pg_enum.enumsortorder), ';')"
                      ),
                      ( "constraints",
-                       "ARRAY_TO_STRING(ARRAY_AGG(pg_constraint.convalidated || ';' || pg_constraint.conname || ';' || pg_get_constraintdef(pg_constraint.oid) ORDER BY pg_constraint.conname), ';')"
+                       "ARRAY_TO_STRING(ARRAY_AGG(pg_constraint.convalidated || ';' || pg_constraint.conname || ';' || pg_get_constraintdef(pg_constraint.oid, true) ORDER BY pg_constraint.conname), ';')"
                      )
                    ],
             -- === Do not include:

--- a/src/Codd/Representations/Database/Pg14.hs
+++ b/src/Codd/Representations/Database/Pg14.hs
@@ -66,8 +66,8 @@ objRepQueryFor allRoles allSchemas schemaAlgoOpts schemaName tableName hobj =
                     "pg_catalog.pg_get_function_arguments(pg_proc.oid)"
                   ),
                   ("config", sortArrayExpr "proconfig"),
-                  ( "definition_md5",
-                    "CASE WHEN pg_language.lanispl OR pg_language.lanname IN ('sql', 'plpgsql') THEN MD5(prosrc) END"
+                  ( "definition",
+                    "CASE WHEN pg_language.lanispl OR pg_language.lanname IN ('sql', 'plpgsql') THEN prosrc END"
                   ),
                   ("kind", "prokind") -- From Pg11.hs
                   -- Multiranges suffer the same sad fate of weird ownership in AWS RDS as regular ranges


### PR DESCRIPTION
- Column order no longer in each column's rep file, but rather in the table's objrep. This makes it much easier to review PRs which change column order by e.g. rewriting a table. Effects on intentional merge conflicts still unknown, but this is a secondary concern
- Full function definitions instead of a md5 hash of them. This should also make it easier to review PRs that make changes to existing functions.
- Pretty print constraint definitions
- Pretty print column types