### PR TITLE
Use hpgsql-simple-compat instead of postgresql-simple

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,14 +60,14 @@ jobs:
     - name: Build statically linked benchmarks
       run: nix-build --no-out-link -A coddbenchmarks
 
-    - name: Build executable used for installer
-      run: nix-build --no-out-link ./nix/install-codd-nixpkgs.nix -A codd
+    # - name: Build executable used for installer
+    #   run: nix-build --no-out-link ./nix/install-codd-nixpkgs.nix -A codd
 
-    - name: Install codd with nix-env and uninstall it
-      run: |
-        nix-env -f ./nix/install-codd-nixpkgs.nix -iA codd
-        codd --help
-        nix-env --uninstall codd
+    # - name: Install codd with nix-env and uninstall it
+    #   run: |
+    #     nix-env -f ./nix/install-codd-nixpkgs.nix -iA codd
+    #     codd --help
+    #     nix-env --uninstall codd
 
     - name: Testing install script posix compatibility
       run: |
@@ -85,7 +85,7 @@ jobs:
         # postgres versions aren't enough to make it worth testing every version here too.
         nix-env -iA concurrently -f ./nix/nixpkgs.nix
         concurrently -g --timings --names pg16Nixpkgs,pg15,pg14,pg13 \
-          'scripts/ci/run-tests-and-annotate-with-error.sh local/pg16Nixpkgs-tests.txt nix-build ./nix/install-codd-nixpkgs.nix --no-out-link -A coddWithCheck' \
+          'scripts/ci/run-tests-and-annotate-with-error.sh local/pg15-tests.txt nix-build --no-out-link -A testsPg16' \
           'scripts/ci/run-tests-and-annotate-with-error.sh local/pg15-tests.txt nix-build --no-out-link -A testsPg15' \
           'scripts/ci/run-tests-and-annotate-with-error.sh local/pg14-tests.txt nix-build --no-out-link -A testsPg14' \
           'scripts/ci/run-tests-and-annotate-with-error.sh local/pg13-tests.txt nix-build --no-out-link -A testsPg13'
@@ -167,7 +167,7 @@ jobs:
         # postgres versions aren't enough to make it worth testing every version here too.
         # We don't run these concurrently because Nix does not have a sandbox in Macs, so it's
         # not worth the risk.
-        scripts/ci/run-tests-and-annotate-with-error.sh local/pg16Nixpkgs-tests.txt nix-build ./nix/install-codd-nixpkgs.nix --no-out-link -A coddWithCheck
+        scripts/ci/run-tests-and-annotate-with-error.sh local/pg15-tests.txt nix-build --no-out-link -A testsPg16
         scripts/ci/run-tests-and-annotate-with-error.sh local/pg15-tests.txt nix-build --no-out-link -A testsPg15
         scripts/ci/run-tests-and-annotate-with-error.sh local/pg14-tests.txt nix-build --no-out-link -A testsPg14
         scripts/ci/run-tests-and-annotate-with-error.sh local/pg13-tests.txt nix-build --no-out-link -A testsPg13
@@ -179,9 +179,9 @@ jobs:
         unzip result/codd.zip -d extracted-bundle
         ./extracted-bundle/codd.app/Contents/MacOS/codd --help # A smoke test
 
-    - name: Install codd with nix-env and uninstall it
-      run: |
-        nix-env -f ./nix/install-codd-nixpkgs.nix -iA codd
-        codd --help
-        nix-env --uninstall codd
+    # - name: Install codd with nix-env and uninstall it
+    #   run: |
+    #     nix-env -f ./nix/install-codd-nixpkgs.nix -iA codd
+    #     codd --help
+    #     nix-env --uninstall codd
 

--- a/codd.cabal
+++ b/codd.cabal
@@ -103,8 +103,7 @@ library
     , haxl
     , mtl
     , network-uri
-    , postgresql-libpq
-    , postgresql-simple
+    , hpgsql-simple-compat
     , resourcet
     , streaming
     , text
@@ -158,7 +157,7 @@ executable codd
       base
     , codd
     , optparse-applicative
-    , postgresql-simple
+    , hpgsql-simple-compat
     , text
     , time
   default-language: Haskell2010
@@ -272,6 +271,7 @@ test-suite codd-test
       aeson >= 2
     , attoparsec
     , base
+    , bytestring
     , codd
     , containers
     , filepath
@@ -280,7 +280,7 @@ test-suite codd-test
     , hspec-core
     , mtl
     , network-uri
-    , postgresql-simple
+    , hpgsql-simple-compat
     , QuickCheck
     , random
     , resourcet

--- a/src/Codd/Internal.hs
+++ b/src/Codd/Internal.hs
@@ -1536,14 +1536,6 @@ applySingleMigration conn registerMigRan skip (AddedSqlMigration sqlMig migTimes
                           error $
                             "Internal error in codd. Erring statements should be in stream's return, not as an element of it. Please report this as a bug: "
                               ++ show states
-                        states@(PQ.TransUnknown, _) ->
-                          error $
-                            "Connection to database may have gone bad. Did someone else kill the connection while codd was applying migrations, perhaps? Codd cannot retry under these circumstances, sadly. Please file a bug report if retrying under such circumstances is important to you: "
-                              ++ show states
-                        states@(_, PQ.TransUnknown) ->
-                          error $
-                            "Connection to database may have gone bad. Did someone else kill the connection while codd was applying migrations, perhaps? Codd cannot retry under these circumstances, sadly. Please file a bug report if retrying under such circumstances is important to you: "
-                              ++ show states
                 )
                 ( numCountableRunnableStmtsToSkip,
                   Nothing,

--- a/src/Codd/Internal.hs
+++ b/src/Codd/Internal.hs
@@ -123,8 +123,7 @@ import UnliftIO
 import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.Directory (listDirectory)
 import UnliftIO.Exception
-  ( IOException,
-    bracket,
+  ( bracket,
     catchJust,
     handleJust,
     throwIO,
@@ -156,7 +155,7 @@ connectWithTimeout connStr timeLimit = do
   -- open for a while. This is probably not very probable, and not a terrible consequence as a single failing connection means
   -- we'll likely close codd itself pretty soon.
   -- The "decent" alternative (which I feel isn't worth it) here is to wrap postgresql-simple's `connectPostgreSQL` in a `onException` that closes the open handle on exception, or copy that code over ourselves and do that here. See https://hackage.haskell.org/package/postgresql-simple-0.7.0.0/docs/src/Database.PostgreSQL.Simple.Internal.html#connectPostgreSQL
-  lastErrorRef <- newIORef (Nothing :: Maybe IOException)
+  lastErrorRef <- newIORef (Nothing :: Maybe DB.SqlError)
   mconn <-
     timeout
       (fromInteger $ diffTimeToPicoseconds timeLimit `div` 1_000_000)
@@ -197,7 +196,7 @@ withConnection connStr timeLimit =
 
 -- | Verifies if a libpq error means the server is not ready to accept connections yet,
 -- either by not being listening at all or still being initializing.
-isServerNotAvailableError :: IOException -> Bool
+isServerNotAvailableError :: DB.SqlError -> Bool
 isServerNotAvailableError e =
   let err = Text.pack $ show e
    in "libpq"
@@ -255,9 +254,9 @@ checkNeedsBootstrapping connInfo connectTimeout =
       connectTimeout
       (fmap (BootstrapCheck True) . detectCoddSchema)
   where
-    isLibPqError :: IOException -> Bool
+    isLibPqError :: DB.SqlError -> Bool
     isLibPqError e =
-      let err = Text.pack $ show e in "libpq: failed" `Text.isInfixOf` err
+      let err = Text.pack $ show e in " does not exist" `Text.isInfixOf` err
 
 data PendingMigrations m = PendingMigrations
   { pendingMigs :: [BlockOfMigrations m],

--- a/src/Codd/Internal/MultiQueryStatement.hs
+++ b/src/Codd/Internal/MultiQueryStatement.hs
@@ -17,13 +17,13 @@ import Codd.Query (txnStatus)
 import Control.Exception (BlockedIndefinitelyOnSTM)
 import Control.Monad (void)
 import Data.Maybe (fromMaybe)
+import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
 import qualified Database.PostgreSQL.LibPQ as PQ
 import qualified Database.PostgreSQL.Simple as DB
 import qualified Database.PostgreSQL.Simple.Copy as DB
-import qualified Database.PostgreSQL.Simple.Internal as PGInternal
 import qualified Database.PostgreSQL.Simple.Types as DB
 import GHC.Num (Natural)
 import Streaming
@@ -35,11 +35,9 @@ import qualified Streaming.Prelude as S
 import qualified Streaming.Prelude as Streaming
 import UnliftIO
   ( Exception,
-    IOException,
     MonadUnliftIO,
     SomeException,
     fromException,
-    handle,
     handleJust,
     liftIO,
     throwIO,
@@ -69,16 +67,10 @@ data StatementApplied
 singleStatement_ ::
   (MonadUnliftIO m) => DB.Connection -> Text -> m StatementApplied
 singleStatement_ conn sql = do
-  res <- liftIO $ PGInternal.exec conn $ encodeUtf8 sql
-  status <- liftIO $ PQ.resultStatus res
-  case status of
-    PQ.CommandOk -> StatementApplied <$> txnStatus conn
-    PQ.TuplesOk -> StatementApplied <$> txnStatus conn
-    _ ->
-      liftIO $
-        handle (pure . StatementErred . SqlStatementException sql) $
-          -- Throw to catch and with that get the statement that failed and error message.. a bit nasty, but should be ok
-          PGInternal.throwResultError "singleStatement_" res status
+  res <- liftIO $ try $ DB.execute_ conn (fromString $ Text.unpack sql)
+  case res of
+    Right _ -> StatementApplied <$> txnStatus conn
+    Left (ex :: DB.SqlError) -> pure $ StatementErred $ SqlStatementException sql ex
 
 -- | Returns a Stream that should be a copy of the supplied stream, but puts a background thread to work on forcing the supplied stream concurrently so the consumer of the returned stream is more likely to find elements without having to wait for them to be produced by upstream.
 -- May evaluate and keep in memory elements ahead of time up to the supplied number+2.
@@ -244,30 +236,10 @@ runSingleStatementInternal_ conn p = case p of
     handleCopyErrors (fromMaybe "" -> stmt) =
       handleJust
         ( \(e :: SomeException) ->
-            -- In my tests, COPY errors are of type `IOException` for `putCopyEnd` and of type `SqlError` for `copy_`.
-            -- Sadly the ones of type `IOException` don't contain e.g. error codes, but at least their message shows the failed statement.
-            -- They also _sometimes_ contain an internal postgresql-simple error concatenated to the actual database error, which isn't great, so we remove it if it's there.
-            -- We should file a bug report to postgresql-simple.
-            -- We transform those into `SqlError` here since all of the codebase is prepared for that.
             case () of
               ()
                 | Just sqlEx <- fromException @DB.SqlError e ->
                     Just sqlEx
-                | Just ioEx <- fromException @IOException e ->
-                    let fullError = Text.pack $ show ioEx
-                     in Just
-                          DB.SqlError
-                            { DB.sqlState = "",
-                              DB.sqlExecStatus = DB.FatalError,
-                              DB.sqlErrorMsg =
-                                encodeUtf8 $
-                                  fromMaybe fullError $
-                                    Text.stripPrefix
-                                      "user error (Database.PostgreSQL.Simple.Copy.putCopyEnd: failed to parse command status\nConnection error: ERROR:  "
-                                      fullError,
-                              DB.sqlErrorDetail = "",
-                              DB.sqlErrorHint = ""
-                            }
                 | otherwise ->
                     Nothing -- Let it blow up if we don't expect it
         )

--- a/src/Codd/Representations/Types.hs
+++ b/src/Codd/Representations/Types.hs
@@ -48,6 +48,7 @@ import Database.PostgreSQL.Simple.FromField
   )
 import Database.PostgreSQL.Simple.ToField
   ( ToField,
+    ToPgField,
   )
 import GHC.Generics (Generic)
 
@@ -163,7 +164,7 @@ fromPathFrag :: FilePath -> ObjName
 fromPathFrag fp = ObjName $ Text.pack fp
 
 newtype ObjName = ObjName {unObjName :: Text}
-  deriving newtype (FromField, ToField, Eq, Ord, Show, Hashable, FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+  deriving newtype (FromField, ToField, ToPgField, Eq, Ord, Show, Hashable, FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 
 class HasName a where
   objName :: a -> ObjName

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,13 @@ extra-deps:
     commit: 6cd30c084debcde9bb83e0f517bbe98cdd80e945
     # nix-sha256: sha256-/P44enZEdgbhULD/3eFNnSinSFlwqXfmvLHDISHBceM=
 
+  - git: https://github.com/mzabani/hpgsql.git
+    commit: b0b831884080d0231482a022b150f9646d494a86
+    # nix-sha256: sha256-t916kTFO5q22ccNYov72hIXMH2s1v+GTkdRSJBBgufs=
+    subdirs:
+      - hpgsql
+      - hpgsql-simple-compat
+
 flags:
   hashable:
     random-initial-seed: true

--- a/test/DbDependentSpecs/AppCommandsSpec.hs
+++ b/test/DbDependentSpecs/AppCommandsSpec.hs
@@ -23,6 +23,7 @@ import Codd.Representations (DbRep (..))
 import Codd.Types (ConnectionString (..))
 import Control.Monad.Trans.Resource (MonadThrow)
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import Data.List (isInfixOf)
 import qualified Data.Map as Map
 import qualified Database.PostgreSQL.Simple as DB
@@ -71,11 +72,10 @@ doesNotCreateDB _act = do
                 }
           }
   runCoddLogger $ do
-    -- libpq's fatal connection error is an IOException
     verifySchema testSettings False
-      `shouldThrow` ( \(e :: IOException) ->
+      `shouldThrow` ( \(e :: DB.SqlError) ->
                         "database \"non-existing-db-name\" does not exist"
-                          `isInfixOf` show e
+                          == DB.sqlErrorMsg e
                     )
 
   withConnection

--- a/test/DbDependentSpecs/RetrySpec.hs
+++ b/test/DbDependentSpecs/RetrySpec.hs
@@ -494,9 +494,9 @@ spec = do
             (migsConnString emptyTestDbInfo)
             testConnTimeout
             (const $ pure ())
-            `shouldThrow` ( \(e :: SomeException) ->
+            `shouldThrow` ( \(e :: DB.SqlError) ->
                               "database \"codd-test-db\" does not exist"
-                                `List.isInfixOf` show e
+                                == DB.sqlErrorMsg e
                           )
           logsmv <- newMVar []
           runMVarLogger


### PR DESCRIPTION
This is a branch to show how many changes were necessary to migrate codd from postgresql-simple and postgresql-libpq to hpgsql-simple-compat (from https://github.com/mzabani/hpgsql).

If you are coming here from hpgsql, I recommend reading each commit individually to see what it took to get codd to migrate to hpgsql-simple-compat. Only the last commit disables building related parts of the pipeline because hpgsql isn't in nixpkgs yet.

This is not to be merged yet because hpgsql lacks many authentication methods libpq provides.